### PR TITLE
docs: add platform icons to bot config navigation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -408,10 +408,15 @@
               },
               {
                 "group": "配置机器人",
+                "icon": "robot",
                 "pages": [
                   "zh/usage/platforms/readme",
                   {
                     "group": "企业微信",
+                    "icon": {
+                      "name": "building-user",
+                      "style": "solid"
+                    },
                     "pages": [
                       "zh/usage/platforms/wecom/wecom",
                       "zh/usage/platforms/wecom/wecomcs",
@@ -420,6 +425,10 @@
                   },
                   {
                     "group": "微信",
+                    "icon": {
+                      "name": "weixin",
+                      "style": "brands"
+                    },
                     "pages": [
                       "zh/usage/platforms/wechat/weixin",
                       "zh/usage/platforms/wechat/wechatpad"
@@ -427,6 +436,10 @@
                   },
                   {
                     "group": "QQ 官方机器人",
+                    "icon": {
+                      "name": "qq",
+                      "style": "brands"
+                    },
                     "pages": [
                       "zh/usage/platforms/qq/official_webhook",
                       "zh/usage/platforms/qq/official"
@@ -434,6 +447,10 @@
                   },
                   {
                     "group": "QQ (OneBot v11)",
+                    "icon": {
+                      "name": "qq",
+                      "style": "brands"
+                    },
                     "pages": [
                       "zh/usage/platforms/qq/aiocqhttp/napcat",
                       "zh/usage/platforms/qq/aiocqhttp/lagrange",
@@ -446,6 +463,7 @@
                   "zh/usage/platforms/kook",
                   {
                     "group": "Satori (QQ 等多平台)",
+                    "icon": "robot",
                     "pages": [
                       "zh/usage/platforms/satori/llonebot"
                     ]

--- a/zh/usage/platforms/dingtalk.mdx
+++ b/zh/usage/platforms/dingtalk.mdx
@@ -1,7 +1,9 @@
 ---
 title: "部署钉钉机器人"
+icon:
+  name: "dingtalk"
+  style: "brands"
 ---
-
 部署 LangBot 到钉钉。
 
 ## 一键配置（推荐）

--- a/zh/usage/platforms/discord.mdx
+++ b/zh/usage/platforms/discord.mdx
@@ -1,7 +1,9 @@
 ---
 title: "接入 Discord 机器人"
+icon:
+  name: "discord"
+  style: "brands"
 ---
-
 ## 创建机器人
 
 前往[Discord 开发者门户](https://discord.com/developers/applications)，登录后，创建应用。

--- a/zh/usage/platforms/kook.mdx
+++ b/zh/usage/platforms/kook.mdx
@@ -1,7 +1,9 @@
 ---
 title: "接入 KOOK 机器人"
+icon:
+  name: "comments"
+  style: "solid"
 ---
-
 ## 创建机器人
 
 前往 [KOOK 开发者中心](https://developer.kookapp.cn/)，登录后进入控制台。

--- a/zh/usage/platforms/lark.mdx
+++ b/zh/usage/platforms/lark.mdx
@@ -1,7 +1,9 @@
 ---
 title: "接入飞书机器人"
+icon:
+  name: "feather"
+  style: "solid"
 ---
-
 ## 一键配置（推荐）
 
 LangBot 支持一键创建飞书应用并自动填写凭证，无需手动复制粘贴。

--- a/zh/usage/platforms/line.mdx
+++ b/zh/usage/platforms/line.mdx
@@ -1,7 +1,9 @@
 ---
 title: "接入LINE机器人"
+icon:
+  name: "line"
+  style: "brands"
 ---
-
 本文介绍如何将 LangBot 与 LINE 平台进行对接，实现 LINE 机器人功能。
 
 ## 创建LINE机器人

--- a/zh/usage/platforms/readme.mdx
+++ b/zh/usage/platforms/readme.mdx
@@ -1,7 +1,7 @@
 ---
 title: "配置机器人 (Bots)"
+icon: "robot"
 ---
-
 机器人用于从消息平台接收消息事件并调用流水线处理消息。
 
 ![arch](/images/zh/deploy/bots/arch.png)

--- a/zh/usage/platforms/slack.mdx
+++ b/zh/usage/platforms/slack.mdx
@@ -1,7 +1,9 @@
 ---
 title: "接入 Slack 机器人"
+icon:
+  name: "slack"
+  style: "brands"
 ---
-
 ## 创建机器人
 
 前往 [Slack的App平台](https://api.slack.com/apps)。

--- a/zh/usage/platforms/telegram.mdx
+++ b/zh/usage/platforms/telegram.mdx
@@ -1,7 +1,9 @@
 ---
 title: "接入 Telegram 机器人"
+icon:
+  name: "telegram"
+  style: "brands"
 ---
-
 ## 创建机器人
 
 前往 [Telegram 机器人创建页面](https://t.me/botfather)，按照提示操作，创建一个机器人。

--- a/zh/usage/platforms/webpage.mdx
+++ b/zh/usage/platforms/webpage.mdx
@@ -1,7 +1,9 @@
 ---
 title: "页面机器人"
+icon:
+  name: "globe"
+  style: "solid"
 ---
-
 通过一行脚本标签将 LangBot 聊天组件嵌入到任何网站。
 
 ## 创建机器人

--- a/zh/usage/platforms/wxoa.mdx
+++ b/zh/usage/platforms/wxoa.mdx
@@ -1,7 +1,9 @@
 ---
 title: "部署微信公众号机器人"
+icon:
+  name: "weixin"
+  style: "brands"
 ---
-
 部署微信公众号机器人接入 LangBot 。
 
 ## LangBot 微信公众号接入模式


### PR DESCRIPTION
## Summary\n- add icons for the Chinese 配置机器人 navigation group and platform subgroups\n- add platform icons to standalone bot platform pages\n\n## Verification\n- `git diff --check`\n- `npx --yes mintlify@4.2.375 dev --port 3333` preview started successfully\n- `npx --yes mintlify@4.2.375 broken-links` still reports existing unrelated broken links