### PR TITLE
fix: exclude repository README from docs sitemap

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,21 @@
+name: Tests
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  seo:
+    name: SEO publishing contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Run SEO contract tests
+        run: npm test

--- a/.mintignore
+++ b/.mintignore
@@ -1,0 +1,2 @@
+# Repository documentation; not part of the published Mintlify site.
+README_EN.md

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "scripts": {
-    "dev": "npx mintlify dev"
+    "dev": "npx mintlify dev",
+    "test": "node --test tests/*.test.mjs"
   },
   "dependencies": {
     "mintlify": "^4.2.375"

--- a/tests/seo.test.mjs
+++ b/tests/seo.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const repoRoot = new URL("../", import.meta.url);
+
+test("repository-only English README is excluded from Mintlify publishing", async () => {
+  const mintignore = await readFile(new URL(".mintignore", repoRoot), "utf8");
+  const patterns = mintignore
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith("#"));
+
+  let ignored = false;
+  for (const pattern of patterns) {
+    if (pattern === "README_EN.md") ignored = true;
+    if (pattern === "!README_EN.md") ignored = false;
+  }
+
+  assert.equal(ignored, true);
+});
+
+test("the historical README_EN URL keeps its permanent canonical redirect", async () => {
+  const docs = JSON.parse(await readFile(new URL("docs.json", repoRoot), "utf8"));
+  const redirects = docs.redirects.filter(
+    (item) => item.source === "/README_EN",
+  );
+
+  assert.equal(redirects.length, 1);
+  assert.equal(redirects[0].destination, "/en/insight/guide");
+  assert.notEqual(redirects[0].permanent, false);
+});


### PR DESCRIPTION
## Summary
- exclude repository-only `README_EN.md` from Mintlify publishing via the documented root `.mintignore`
- preserve the permanent `/README_EN` redirect to `/en/insight/guide`
- add regression tests and a lightweight PR workflow

## Verification
- `npm test` (2/2 passing)
- `git diff --check`
- independent fail-closed review: passed

## Official guidance
- https://www.mintlify.com/docs/organize/mintignore
- https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap