### PR TITLE
ci: update Actions runtimes

### DIFF
--- a/.github/workflows/sync-github-wiki.yml
+++ b/.github/workflows/sync-github-wiki.yml
@@ -32,8 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
       - name: Run converter tests
@@ -46,7 +46,7 @@ jobs:
           test -f dist/github-wiki/_Sidebar.md
           test "$(find dist/github-wiki -maxdepth 1 -name '*.md' | wc -l)" -gt 250
       - name: Upload generated Wiki
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: github-wiki
           path: dist/github-wiki
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: github-wiki
           path: generated

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: "22"
       - name: Run SEO contract tests


### PR DESCRIPTION
## Summary
- update GitHub Actions to their current Node 24-based major versions
- remove Node 20 deprecation warnings from Wiki sync and SEO workflows

## Verification
- converter unit tests pass
- action release tags verified via GitHub API