### PR TITLE
docs(models): note OpenAI-compatible multi-model gateway Request URL

### DIFF
--- a/en/usage/models/readme.mdx
+++ b/en/usage/models/readme.mdx
@@ -27,6 +27,8 @@ You can add multiple models, and then select which model to use in the pipeline.
 
 Enter these four parameters: `Model Name`, `Model Provider`, `Request URL`, and `API Key`, then submit.
 
+For OpenAI-compatible multi-model gateways, set **Model Provider** to an OpenAI-compatible option and point **Request URL** at the gateway's `/v1` endpoint — for example [DaoXE](https://daoxe.com) at `https://api.daoxe.com/v1` (use an exact model id from the gateway).
+
 For model capabilities, enable the ones the underlying model actually supports:
 
 - **Vision**: enable to recognize images


### PR DESCRIPTION
## Summary

The custom models docs already explain configuring `Request URL` for third-party providers.

This PR notes that OpenAI-compatible multi-model gateways work the same way, using [DaoXE](https://daoxe.com) (`https://api.daoxe.com/v1`) as one concrete example.

Docs only — no runtime behavior changes.

## Test plan
- [ ] Models page renders
- [ ] Existing custom-model steps unchanged
- [ ] Tip is clearly optional

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>