### PR TITLE
docs(config): sync complete runtime settings reference

### DIFF
--- a/en/deploy/settings.mdx
+++ b/en/deploy/settings.mdx
@@ -1,18 +1,57 @@
 ---
 title: "System Environment Settings"
-description: "Configure LangBot system environment variables and runtime settings for your AI bot deployment."
+description: "Complete reference for LangBot config.yaml: API, concurrency, databases, storage, plugins, MCP, monitoring, and Box."
 ---
 
-Configure system runtime settings in `data/config.yaml`.
-Generally, no modification is needed.
+LangBot runtime configuration lives in `data/config.yaml`. The first startup generates it from the default template. The example below is kept aligned with [`src/langbot/templates/config.yaml`](https://github.com/langbot-app/LangBot/blob/master/src/langbot/templates/config.yaml).
+
+<Info>
+Most self-hosted deployments only need to change public URLs, databases/vector stores, object storage, and Box Runtime. Keep capacity and Cloud safety limits at their defaults unless you understand their operational impact.
+</Info>
+
+## Complete default configuration
 
 ```yaml
-admins: []
 api:
     port: 5300
     webhook_prefix: 'http://127.0.0.1:5300'
     extra_webhook_prefix: ''
-    global_api_key: ''  # Global API key. When non-empty, it is accepted for both the HTTP API and the MCP server (/mcp) with no login session, no database record, and no lbk_ prefix required. Empty = disabled. Stored in plaintext — enable only on trusted/internal deployments and serve over HTTPS.
+    # Canonical browser origin when WebUI and API use different origins in
+    # development (for example http://localhost:3000). Production bundled UI
+    # may leave this empty when webhook_prefix already has the browser origin.
+    # OAuth redirects trust only these server-side values, never request Host
+    # or Origin headers.
+    webui_url: ''
+    # Global API key for the HTTP service API and the MCP server. When set to a
+    # non-empty string, this key is accepted anywhere a web-UI-created API key is
+    # accepted (X-API-Key header or "Authorization: Bearer <key>"), WITHOUT any
+    # login session and without a database record. Leave empty to disable.
+    # Keep this value secret; only enable it on trusted/internal deployments.
+    global_api_key: ''
+workspace:
+    invitations:
+        # Public WebUI origin used to build invitation links. Leave empty to
+        # use api.webui_url, then api.webhook_prefix. Set via
+        # WORKSPACE__INVITATIONS__PUBLIC_WEB_URL in container deployments.
+        public_web_url: ''
+        email:
+            # Optional invitation email delivery. Empty provider keeps
+            # invitations link-only. Supported: resend, smtp.
+            provider: ''
+            from: ''
+            timeout_seconds: 10
+            resend:
+                api_url: 'https://api.resend.com/emails'
+                # Secret. Set via WORKSPACE__INVITATIONS__EMAIL__RESEND__API_KEY.
+                api_key: ''
+            smtp:
+                host: ''
+                port: 587
+                username: ''
+                # Secret. Set via WORKSPACE__INVITATIONS__EMAIL__SMTP__PASSWORD.
+                password: ''
+                starttls: true
+                ssl: false
 command:
     enable: true
     prefix:
@@ -22,6 +61,35 @@ command:
 concurrency:
     pipeline: 20
     session: 1
+    # Hard admission limits for queued + running pipeline queries.
+    pending_queries: 1000
+    pending_queries_per_workspace: 100
+webhooks:
+    # Bound database materialization and per-message outbound fan-out.
+    # Existing rows above this limit remain deletable through the management
+    # API, but only this many enabled destinations are dispatched.
+    # Supports WEBHOOKS__MAX_PER_WORKSPACE (hard cap: 64).
+    max_per_workspace: 16
+    # Instance-wide request admission. Delivery fails open when every slot is
+    # occupied instead of retaining an unbounded queue of webhook tasks.
+    # Supports WEBHOOKS__MAX_INFLIGHT_REQUESTS (hard cap: 128).
+    max_inflight_requests: 16
+cloud:
+    # Operational safety ceilings for the one logical Cloud instance. These
+    # are not subscription entitlements. An authoritative directory update
+    # that would exceed them is rejected atomically rather than truncated.
+    directory:
+        # Tune downward from the measured production capacity curve. Core has
+        # an absolute safety ceiling of 5,000 active Workspaces.
+        max_active_workspaces: 1000
+        # Full snapshots contain current Workspaces only. Archived tombstones
+        # are delivered through bounded per-Workspace deltas.
+        max_snapshot_workspaces: 1000
+        # Aggregate memberships accepted in one signed snapshot or delta.
+        max_snapshot_memberships: 20000
+        # Signed control-plane envelope buffered by the closed adapter before
+        # JSON/JWS verification (32 MiB; absolute maximum 64 MiB).
+        max_response_bytes: 33554432
 proxy:
     http: ''
     https: ''
@@ -31,13 +99,62 @@ system:
     recovery_key: ''
     allow_modify_login_info: true
     disabled_adapters: []
+    blocking_executor:
+        # All asyncio.to_thread work shares this process-wide bounded pool.
+        # Both running threads and queued calls are capped to prevent tenant
+        # bursts from creating an unbounded queue of retained request objects.
+        max_workers: 8
+        max_pending: 128
+        # One trusted Workspace can occupy at most this many running + queued
+        # slots. This must not exceed half of max_workers.
+        max_inflight_per_scope: 4
+    # Public outbound IP addresses of this LangBot deployment. Some platforms
+    # (e.g. WeCom, WeChat Official Account, QQ Official API) require the
+    # caller's IPs to be added to their trusted-IP / IP-whitelist settings.
+    # When set, the web UI shows these IPs on the bot config form of such
+    # adapters. Also settable via the SYSTEM__OUTBOUND_IPS env var
+    # (comma-separated). Empty list = hidden in the web UI.
+    outbound_ips: []
     limitation:
         max_bots: -1
         max_pipelines: -1
         max_extensions: -1
+        max_knowledge_bases: -1
+        # When set to a non-empty string, every pipeline is forced to use this
+        # Box sandbox-scope template regardless of its own configuration, and
+        # the per-pipeline "Sandbox Scope" selector is locked in the web UI.
+        # Used by SaaS deployments to confine a tenant to a single shared
+        # sandbox (set to '{global}'). Empty string = no restriction.
+        force_box_session_id_template: ''
     task_retention:
         # Keep at most this many completed async task records in memory
         completed_limit: 200
+        # Bound progress output retained by one task, including running tasks.
+        max_log_chars: 200000
+        # Protect the shared process from user-triggered operation storms.
+        max_active_user_tasks: 256
+        max_active_user_tasks_per_workspace: 8
+    session_retention:
+        # Process-local conversation sessions are a cache, not durable history.
+        max_entries: 2000
+        max_entries_per_workspace: 200
+        idle_ttl_seconds: 86400
+        max_conversations_per_session: 20
+        max_messages_per_conversation: 100
+    websocket_retention:
+        # Bound live browser sockets and per-Workspace fan-out in the shared process.
+        max_connections: 1024
+        max_connections_per_workspace: 32
+        # Idle proxy runtimes are evicted when this process-local cache fills.
+        max_workspace_proxies: 1024
+        max_conversations_per_workspace: 200
+        max_messages_per_conversation: 100
+        conversation_idle_ttl_seconds: 86400
+        send_queue_size: 100
+    response_limits:
+        # Defense in depth for tenant-configured upstream providers.
+        max_generated_chars: 1048576
+        max_stream_chunks: 100000
     jwt:
         expire: 604800
         secret: ''
@@ -46,13 +163,33 @@ database:
     sqlite:
         path: 'data/langbot.db'
     postgresql:
+        # Optional SQLAlchemy URL (postgresql[+asyncpg]://...). When set, it
+        # overrides the structured fields and preserves TLS/query options.
+        url: ''
         host: '127.0.0.1'
         port: 5432
         user: 'postgres'
         password: 'postgres'
         database: 'postgres'
+        # One bounded pool is shared by business data and Cloud pgvector.
+        pool_size: 10
+        max_overflow: 10
+        pool_timeout_seconds: 30
+        pool_recycle_seconds: 1800
+        # Applied only to Cloud runtime connections. The one-shot release
+        # migration uses its operator connection without these short limits.
+        statement_timeout_ms: 60000
+        lock_timeout_ms: 5000
+        idle_in_transaction_session_timeout_ms: 60000
+    cloud_migration:
+        # `langbot migrate --cloud` reads an operator-only PostgreSQL DSN from
+        # this environment variable. The operator role must differ from the
+        # runtime role above; never put its password in this file or CLI args.
+        operator_dsn_env: 'LANGBOT_CLOUD_MIGRATION_DSN'
 vdb:
     use: chroma
+    # Bound process-local collection/index handles across all Workspaces.
+    runtime_cache_limit: 1024
     qdrant:
         url: ''
         host: localhost
@@ -74,6 +211,11 @@ vdb:
         token: ''
         db_name: ''
     pgvector:
+        # SaaS/shared-schema deployments reuse database.postgresql. OSS can
+        # keep this false when deliberately using an external pgvector DB.
+        use_business_database: false
+        # Release migrations create one partial ANN index per enabled value.
+        allowed_dimensions: [384, 512, 768, 1024, 1536]
         host: '127.0.0.1'
         port: 5433
         database: 'langbot'
@@ -81,16 +223,19 @@ vdb:
         password: 'postgres'
     valkey_search:
         host: 'localhost'
-        port: 6379
+        port: 6379            # integration tests use 6380 -> valkey/valkey-bundle:9.1.0
         db: 0
-        username: ''      # Optional (ACL user)
-        password: ''      # Optional (ACL / requirepass), never logged
-        tls: false        # Optional, for toB/SaaS deployments
-        index_algorithm: 'HNSW'    # HNSW (approximate) or FLAT (exact)
-        distance_metric: 'COSINE'  # COSINE, L2, or IP
-        request_timeout: 5000      # Per-request timeout in ms
+        password: ''          # optional (toB auth)
+        username: ''          # optional (ACL user, toB)
+        tls: false            # optional (toB/SaaS)
+        index_algorithm: 'HNSW'   # HNSW | FLAT
+        distance_metric: 'COSINE' # COSINE | L2 | IP
+        request_timeout: 5000     # per-request timeout in ms (glide default 250ms is too low for KNN)
 storage:
     use: local
+    # Bound every object materialized into Core memory. Built-in Local/S3
+    # providers enforce this while reading (hard cap: 64 MiB).
+    max_object_read_bytes: 10485760
     cleanup:
         # Enable periodic cleanup of local/S3 uploaded files and old log files
         enabled: true
@@ -100,21 +245,79 @@ storage:
         uploaded_file_retention_days: 7
         # LangBot log files older than this many days will be deleted
         log_retention_days: 3
+        # Bound per-Workspace file cleanup and diagnostic candidate lists.
+        # Supports STORAGE__CLEANUP__MAX_FILES_PER_RUN (hard cap: 10000).
+        max_files_per_run: 1000
     s3:
         endpoint_url: ''
         access_key_id: ''
         secret_access_key: ''
         region: 'us-east-1'
         bucket: 'langbot-storage'
+        # boto3 is synchronous; bound the number of operations delegated to
+        # worker threads so an S3 slowdown cannot saturate the process.
+        max_concurrency: 16
 plugin:
     enable: true
     runtime_ws_url: 'ws://langbot_plugin_runtime:5400/control/ws'
     enable_marketplace: true
     display_plugin_debug_url: 'ws://localhost:5401/plugin/debug/ws'
+    worker:
+        # Instance-wide maximum for every plugin installation. Plugin
+        # manifests cannot raise or override these limits.
+        max_cpus: 1.0
+        max_memory_mb: 512
+        max_pids: 128
+        max_open_files: 256
+        max_file_size_mb: 512
+        # Instance-wide admission budgets. The effective worker count is the
+        # lowest of max_workers, max_total_cpus/max_cpus and
+        # max_total_memory_mb/max_memory_mb.
+        max_workers: 16
+        max_total_cpus: 8.0
+        max_total_memory_mb: 8192
+        # Includes disabled and historical installation fences retained to
+        # reject stale desired-state replay.
+        max_installations: 10000
+        # Restart storms are globally serialized by default. Repeated
+        # unexpected exits within the configured window open a Runtime-wide
+        # circuit; one half-open probe must remain stable before other
+        # installations may restart.
+        max_concurrent_restarts: 1
+        restart_failure_threshold: 8
+        restart_failure_window_seconds: 30.0
+        restart_circuit_open_seconds: 60.0
+        # Cloud shared Runtime sets this to true and fails closed unless
+        # delegated cgroup v2 controllers are available.
+        require_hard_limits: false
     binary_storage:
         # Max bytes for a single plugin binary storage value
         max_value_bytes: 10485760
+mcp:
+    # Bound instance-wide MCP startup and shutdown bursts. Supports
+    # MCP__LIFECYCLE_CONCURRENCY and is clamped to a maximum of 128.
+    lifecycle_concurrency: 16
+    stdio:
+        # Independent gate for local stdio MCP transports. Cloud v2 sets
+        # MCP__STDIO__ENABLED=false even when Box Runtime is available.
+        enabled: true
 monitoring:
+    query_limits:
+        # Maximum records materialized by one paginated monitoring request.
+        # Supports MONITORING__QUERY_LIMITS__PAGE_ROWS (hard cap: 5000).
+        page_rows: 1000
+        # CSV exports are currently assembled in memory. Keep this lower than
+        # the historical 100000-row default (hard cap: 50000).
+        export_rows: 10000
+        # Maximum related records returned by one session/message detail view
+        # (hard cap: 10000). Aggregate statistics remain database-computed.
+        detail_rows: 2000
+        # Token charts are grouped in SQL and return only the newest buckets
+        # (hard cap: 10000). Supports an environment variable override.
+        timeseries_buckets: 1000
+        # Bound high-offset scans that can otherwise monopolize PostgreSQL CPU
+        # (hard cap: 10000000).
+        max_offset: 1000000
     auto_cleanup:
         # Enable automatic cleanup of expired monitoring records
         enabled: true
@@ -124,22 +327,74 @@ monitoring:
         check_interval_hours: 1
         # Number of expired rows to delete per table batch
         delete_batch_size: 1000
+        # Prevent one large Workspace backlog from monopolizing PostgreSQL.
+        # Supports MONITORING__AUTO_CLEANUP__MAX_BATCHES_PER_TABLE_PER_RUN.
+        max_batches_per_table_per_run: 4
 box:
-    enabled: true  # Master switch for Box Runtime. When false, Box-dependent features such as sandbox tools, Skill add/edit, and stdio MCP are disabled.
+    # Master switch for the Box sandbox runtime. When false, LangBot does NOT
+    # attempt to connect to a remote Box runtime nor start a local stdio Box
+    # subprocess. Disabling Box also disables every feature that depends on it:
+    # the native sandbox tools (exec/read/write/edit/glob/grep), the activate
+    # skill tool, skill add/edit, and stdio-mode MCP servers. Skills can still
+    # be listed read-only and http/sse MCP servers continue to work.
+    enabled: true
     backend: 'local'  # 'local' (Docker/nsjail), 'docker', 'nsjail', or 'e2b'. Can be written via BOX__BACKEND.
     runtime:
-        endpoint: ''  # External Box Runtime base URL, e.g. 'ws://127.0.0.1:5410'. When empty, non-Docker deployments use a locally managed Runtime; Docker deployments connect to langbot_box:5410 on the Compose network.
+        # External WebSocket runtimes also require LANGBOT_BOX_CONTROL_TOKEN in
+        # both LangBot and Box. Keep the shared secret out of this config file.
+        endpoint: ''  # External Box Runtime base URL, e.g. 'ws://127.0.0.1:5410'. Leave empty for local auto-managed runtime.
+    limits:
+        max_sessions: 64
+        max_managed_processes: 64
+        max_completed_processes: 256
+        # Core scans a Workspace before and after quota-enforced executions.
+        # Fail closed instead of repeatedly walking an inode bomb.
+        # Supports BOX__LIMITS__MAX_WORKSPACE_ENTRIES (hard cap: 1000000).
+        max_workspace_entries: 100000
+        # Retained admission fences prevent replay after entitlement expiry or
+        # revocation. Fail closed before that monotonic state can grow without
+        # bound; Cloud may override this with BOX__LIMITS__MAX_ADMISSION_RECORDS.
+        max_admission_records: 100000
+        max_rpc_file_bytes: 20971520
+    # Cloud v2 overrides these values through the instance config/environment.
+    # OSS keeps admission disabled and preserves the existing multi-session
+    # local behavior. These limits are Runtime-owned and cannot be relaxed by
+    # a pipeline, Workspace entitlement, or tool call.
+    admission:
+        required: false
+        logical_session_id: 'global'
+        required_backend: 'nsjail'
+        max_sessions: 1
+        max_managed_processes: 0
+        max_grant_ttl_sec: 300
+        max_timeout_sec: 120
+        cpus: 1.0
+        memory_mb: 512
+        pids_limit: 128
+        read_only_rootfs: true
+        # OSS admission-disabled mode uses 0 for unlimited compatibility.
+        # Cloud bootstrap requires a positive hard quota.
+        workspace_quota_mb: 0
+        readiness_cache_sec: 15
     local:
         profile: 'default'
         image: ''  # Custom local sandbox image. Leave empty to use the profile default.
-        host_root: './data/box'  # Base host directory for local workspace mounts. Docker deployments should use an absolute host path mounted by langbot_box.
-        default_workspace: ''  # Defaults to '<host_root>/default'.
-        skills_root: 'skills'  # Box-owned Skill package directory. Relative paths are resolved under host_root.
+        host_root: './data/box'  # Base host directory for local workspace mounts. Docker deployments should override this with an absolute host path.
+        default_workspace: ''  # Defaults to '<host_root>/default'. Relative paths are resolved under host_root.
+        skills_root: 'skills'  # Box-owned skill package directory. Relative paths are resolved under host_root.
         allowed_mount_roots:  # Defaults to ['<host_root>'] when left empty.
             - './data/box'
             - '/tmp'
         workspace_quota_mb: null  # Optional disk quota override (>= 0). null = profile default.
-    default_memory_mb: 1536  # Default nsjail cgroup memory limit per MCP stdio process (MB). Node.js MCP servers (npx/bunx) need more than Python ones due to V8 + WASM overhead. Too low = return_code=137 (OOM). Override per-server with box.memory_mb. Env: BOX__DEFAULT_MEMORY_MB.
+    # Default nsjail cgroup memory limit for each MCP stdio server process, in MB.
+    # Node.js MCP servers (npx/bunx) need more memory than Python ones because V8
+    # and WebAssembly modules (e.g. undici llhttp) reserve large virtual address
+    # space at startup. Setting this too low causes processes to be killed with
+    # return_code=137 (OOM kill); the symptom is "Box managed process exited
+    # unexpectedly" in the logs.  Raise on machines with ample RAM; lower only if
+    # you run exclusively Python (uvx) MCP servers.
+    # Can also be set via BOX__DEFAULT_MEMORY_MB. Default: 1536.
+    default_memory_mb: 1536
     docker:
         cpu_limit_enabled: true  # When false, Docker sandbox containers are started without --cpus. Memory and PID limits still apply.
     e2b:
@@ -151,39 +406,76 @@ space:
     url: 'https://space.langbot.app'
     # Space API URL for model requests (MaaS)
     models_gateway_api_url: 'https://api.langbot.cloud/v1'
-    # OAuth authorization page URL
+    # OAuth authorization page URL (user will be redirected here)
     oauth_authorize_url: 'https://space.langbot.app/auth/authorize'
     disable_models_service: false
     disable_telemetry: false
 ```
 
-## Notes
+## Configuration groups
 
-- `storage.cleanup.uploaded_file_retention_days` only cleans temporary uploaded files at the storage root. It does not delete plugin configuration files or internal objects stored under directories.
-- `storage.cleanup.log_retention_days` cleans old log files by the date in their file names. The default keeps at most 3 days of logs.
-- When SQLite is used as the database, automatic monitoring cleanup directly releases database file space after deleting expired records.
-- `plugin.binary_storage.max_value_bytes` limits the size of a single plugin binary storage value. The default is 10 MiB.
-- The WebUI sidebar includes a “Storage Analysis” page for viewing database, logs, uploaded files, vector store, plugins, MCP, temporary files, and cleanup candidates.
-- `vdb.valkey_search` uses the [Valkey Search](https://valkey.io/) module via the official async `valkey-glide` client and supports vector, full-text, and hybrid search. Run a server with the module loaded, e.g. `valkey/valkey-bundle:9.1.0` (`docker run -d -p 6379:6379 valkey/valkey-bundle:9.1.0`). Note: hybrid search follows a filter-then-KNN model, so the `vector_weight` parameter is accepted but **not honored** (a native Valkey Search limitation). The connection is lazy, so a down or misconfigured server does not block startup. See the [Valkey Search integration doc](https://github.com/langbot-app/LangBot/blob/master/docs/VALKEY_SEARCH_INTEGRATION.md) for details.
-- `api.global_api_key` is a global API key for agents / automation: once set, calls to the HTTP API or the built-in MCP server (`/mcp`) authenticate by sending `X-API-Key: <key>` or `Authorization: Bearer *** — no login session and no database-stored `lbk_` key required. It is stored in plaintext in `config.yaml`, so enable it only on trusted / internal deployments and serve it over HTTPS. See [API Key Authentication](https://github.com/langbot-app/LangBot/blob/master/docs/API_KEY_AUTH.md).
+### API, WebUI, and invitations
 
-## Set Configuration Via Environment Variables
+- `api.port` is the HTTP API and WebUI port. `api.webhook_prefix` is the public base URL used to generate platform callback URLs; production deployments normally set it to the HTTPS reverse-proxy origin.
+- Set `api.webui_url` when the browser UI and API use different origins. OAuth redirects trust only this server-side value and `webhook_prefix`, never request `Host` or `Origin` headers.
+- `api.global_api_key` authenticates the HTTP Service API and built-in MCP server through `X-API-Key` or `Authorization: Bearer`, without a login session or a database-backed `lbk_` key. Empty means disabled.
+- `workspace.invitations.public_web_url` controls invitation links and falls back to `api.webui_url`, then `api.webhook_prefix`. Email delivery is optional; choose `resend` or `smtp`, or leave `provider` empty for link-only invitations.
 
-The configuration in `config.yaml` can be set via environment variables. Environment variable names use uppercase letters and double underscores, for example: `API__PORT` represents `api.port`.
+<Warning>
+Treat the global API key, JWT secret, database credentials, S3 credentials, email-provider secrets, and E2B key as secrets. Prefer environment variables in production, never commit real values, and expose authenticated endpoints only over HTTPS.
+</Warning>
 
-- `API__PORT` represents `api.port`
-- `CONCURRENCY__PIPELINE` represents `concurrency.pipeline`
-- `DATABASE__SQLITE__PATH` represents `database.sqlite.path`
-- `STORAGE__CLEANUP__UPLOADED_FILE_RETENTION_DAYS` represents `storage.cleanup.uploaded_file_retention_days`
-- `STORAGE__CLEANUP__LOG_RETENTION_DAYS` represents `storage.cleanup.log_retention_days`
-- `MONITORING__AUTO_CLEANUP__RETENTION_DAYS` represents `monitoring.auto_cleanup.retention_days`
-- `PLUGIN__BINARY_STORAGE__MAX_VALUE_BYTES` represents `plugin.binary_storage.max_value_bytes`
-- `BOX__BACKEND` represents `box.backend`
-- `BOX__LOCAL__HOST_ROOT` represents `box.local.host_root`
-- `BOX__LOCAL__SKILLS_ROOT` represents `box.local.skills_root`
+### Admission and capacity limits
 
-On startup, LangBot reads all environment variables, applies the corresponding configuration to `config.yaml`, and writes it to `data/config.yaml`.
+- `concurrency` bounds running and queued pipeline work globally and per Workspace.
+- `webhooks` bounds enabled destinations per Workspace and instance-wide outbound requests. Full request admission fails open rather than retaining an unbounded task queue.
+- `cloud.directory` contains operational safety ceilings for one logical Cloud instance, not subscription entitlements. Oversized authoritative directory updates are rejected atomically instead of being truncated. Most self-hosted deployments should keep these defaults.
+- `system.blocking_executor`, `task_retention`, `session_retention`, `websocket_retention`, and `response_limits` bound process-local workers, cached records, sockets, and upstream output.
+- Values under `system.limitation` are instance limits; `-1` means unlimited. `force_box_session_id_template` is intended for SaaS sandbox confinement and should remain empty for normal self-hosting.
+
+### Databases and vector stores
+
+- `database.use` selects SQLite or PostgreSQL. A non-empty `database.postgresql.url` overrides the structured connection fields and preserves TLS/query options.
+- PostgreSQL pool and timeout settings bound shared runtime resources. `database.cloud_migration.operator_dsn_env` names the environment variable containing the operator-only migration DSN; keep that role separate from the runtime role.
+- `vdb.use` selects the vector backend. Configure only the selected backend. `runtime_cache_limit` bounds process-local collection/index handles.
+- `vdb.pgvector.use_business_database` reuses `database.postgresql`; `allowed_dimensions` controls the partial ANN indexes created by release migrations.
+- Valkey Search requires a Valkey server with the Search module, such as `valkey/valkey-bundle:9.1.0`.
+
+### Storage, plugins, MCP, and monitoring
+
+- `storage.max_object_read_bytes` caps objects materialized into Core memory. Cleanup limits bound file scans, and `s3.max_concurrency` bounds synchronous boto3 operations delegated to worker threads.
+- `plugin.worker` defines hard per-installation and instance-wide budgets. Plugin manifests cannot raise them. Restart-window settings suppress Runtime restart storms.
+- `mcp.lifecycle_concurrency` bounds MCP startup/shutdown bursts. `mcp.stdio.enabled` can disable local stdio transports without disabling HTTP/SSE MCP servers.
+- Monitoring query and cleanup limits prevent large pages, exports, offsets, or backlogs from monopolizing memory or PostgreSQL.
+
+### Box sandbox
+
+- `box.enabled` is the master switch. Disabling it also disables native sandbox tools, Skill add/edit, and stdio MCP, while read-only Skill listing and HTTP/SSE MCP remain available.
+- `box.backend` selects `local`, `docker`, `nsjail`, or `e2b`; `runtime.endpoint` connects an external WebSocket Runtime.
+- `box.limits` bounds sessions, processes, workspace scans, retained admission fences, and RPC file size.
+- `box.admission` is the Cloud v2 hard-admission policy. OSS defaults to `required: false`; pipelines, Workspace entitlements, and tool calls cannot relax Runtime-owned limits.
+- `box.local` controls workspace roots and mount allowlists. In Docker deployments, use an absolute `host_root` that the Box container can mount.
+- `box.default_memory_mb` is the default nsjail cgroup limit for each stdio MCP process. Node.js MCP servers usually need more memory than Python servers; too little commonly produces exit code `137`.
+
+### LangBot Space
+
+`space.url`, `models_gateway_api_url`, and `oauth_authorize_url` control Space OAuth/API and MaaS endpoints. The two `disable_*` flags independently disable model service use and telemetry.
+
+## Environment-variable overrides
+
+Convert a nested key to uppercase and join levels with double underscores:
+
+- `API__PORT` → `api.port`
+- `WORKSPACE__INVITATIONS__PUBLIC_WEB_URL` → `workspace.invitations.public_web_url`
+- `CONCURRENCY__PENDING_QUERIES_PER_WORKSPACE` → `concurrency.pending_queries_per_workspace`
+- `DATABASE__POSTGRESQL__POOL_SIZE` → `database.postgresql.pool_size`
+- `STORAGE__CLEANUP__MAX_FILES_PER_RUN` → `storage.cleanup.max_files_per_run`
+- `PLUGIN__WORKER__MAX_TOTAL_MEMORY_MB` → `plugin.worker.max_total_memory_mb`
+- `MCP__STDIO__ENABLED` → `mcp.stdio.enabled`
+- `BOX__DEFAULT_MEMORY_MB` → `box.default_memory_mb`
+
+At startup, LangBot applies these overrides and writes the resulting configuration to `data/config.yaml`.
 
 <Note>
-Set Box-related configuration on the `langbot` service with the unified `BOX__*` environment variables. LangBot applies them to `data/config.yaml` on startup and sends the Box configuration to `langbot_box` through INIT RPC. Do not set `LANGBOT_BOX_*` or `BOX__*` on the `langbot_box` service; they are not read directly there.
+In Docker deployments, set unified `BOX__*` variables on the `langbot` service. LangBot sends Box configuration to `langbot_box` through INIT RPC; variables set directly on `langbot_box` are not read.
 </Note>

--- a/ja/deploy/settings.mdx
+++ b/ja/deploy/settings.mdx
@@ -1,18 +1,57 @@
 ---
 title: "システム環境設定"
-description: "LangBot のシステム環境変数とランタイム設定を構成し、AI ボットのデプロイをカスタマイズ。"
+description: "LangBot config.yaml の API、並行処理、DB、ストレージ、プラグイン、MCP、監視、Box の完全リファレンス。"
 ---
 
-システム動作のための環境情報を設定します。設定ファイルは `data/config.yaml` にあります。
-通常、変更は必要ありません。
+LangBot の実行設定は `data/config.yaml` にあります。初回起動時に既定テンプレートから生成されます。以下の例は [`src/langbot/templates/config.yaml`](https://github.com/langbot-app/LangBot/blob/master/src/langbot/templates/config.yaml) と同期しています。
+
+<Info>
+通常のセルフホストで変更が必要なのは主に公開 URL、DB/ベクトルストア、オブジェクトストレージ、Box Runtime です。用途を理解していない容量・Cloud 安全上限は既定値を維持してください。
+</Info>
+
+## 完全なデフォルト設定
 
 ```yaml
-admins: []
 api:
     port: 5300
     webhook_prefix: 'http://127.0.0.1:5300'
     extra_webhook_prefix: ''
-    global_api_key: ''  # グローバル API キー。空でない場合、HTTP API と MCP サーバー（/mcp）の両方で、ログインセッション・データベースレコード・`lbk_` プレフィックス不要で認証されます。空 = 無効。平文で保存されるため、信頼できる / 内部デプロイでのみ有効化し、HTTPS で公開してください。
+    # Canonical browser origin when WebUI and API use different origins in
+    # development (for example http://localhost:3000). Production bundled UI
+    # may leave this empty when webhook_prefix already has the browser origin.
+    # OAuth redirects trust only these server-side values, never request Host
+    # or Origin headers.
+    webui_url: ''
+    # Global API key for the HTTP service API and the MCP server. When set to a
+    # non-empty string, this key is accepted anywhere a web-UI-created API key is
+    # accepted (X-API-Key header or "Authorization: Bearer <key>"), WITHOUT any
+    # login session and without a database record. Leave empty to disable.
+    # Keep this value secret; only enable it on trusted/internal deployments.
+    global_api_key: ''
+workspace:
+    invitations:
+        # Public WebUI origin used to build invitation links. Leave empty to
+        # use api.webui_url, then api.webhook_prefix. Set via
+        # WORKSPACE__INVITATIONS__PUBLIC_WEB_URL in container deployments.
+        public_web_url: ''
+        email:
+            # Optional invitation email delivery. Empty provider keeps
+            # invitations link-only. Supported: resend, smtp.
+            provider: ''
+            from: ''
+            timeout_seconds: 10
+            resend:
+                api_url: 'https://api.resend.com/emails'
+                # Secret. Set via WORKSPACE__INVITATIONS__EMAIL__RESEND__API_KEY.
+                api_key: ''
+            smtp:
+                host: ''
+                port: 587
+                username: ''
+                # Secret. Set via WORKSPACE__INVITATIONS__EMAIL__SMTP__PASSWORD.
+                password: ''
+                starttls: true
+                ssl: false
 command:
     enable: true
     prefix:
@@ -22,6 +61,35 @@ command:
 concurrency:
     pipeline: 20
     session: 1
+    # Hard admission limits for queued + running pipeline queries.
+    pending_queries: 1000
+    pending_queries_per_workspace: 100
+webhooks:
+    # Bound database materialization and per-message outbound fan-out.
+    # Existing rows above this limit remain deletable through the management
+    # API, but only this many enabled destinations are dispatched.
+    # Supports WEBHOOKS__MAX_PER_WORKSPACE (hard cap: 64).
+    max_per_workspace: 16
+    # Instance-wide request admission. Delivery fails open when every slot is
+    # occupied instead of retaining an unbounded queue of webhook tasks.
+    # Supports WEBHOOKS__MAX_INFLIGHT_REQUESTS (hard cap: 128).
+    max_inflight_requests: 16
+cloud:
+    # Operational safety ceilings for the one logical Cloud instance. These
+    # are not subscription entitlements. An authoritative directory update
+    # that would exceed them is rejected atomically rather than truncated.
+    directory:
+        # Tune downward from the measured production capacity curve. Core has
+        # an absolute safety ceiling of 5,000 active Workspaces.
+        max_active_workspaces: 1000
+        # Full snapshots contain current Workspaces only. Archived tombstones
+        # are delivered through bounded per-Workspace deltas.
+        max_snapshot_workspaces: 1000
+        # Aggregate memberships accepted in one signed snapshot or delta.
+        max_snapshot_memberships: 20000
+        # Signed control-plane envelope buffered by the closed adapter before
+        # JSON/JWS verification (32 MiB; absolute maximum 64 MiB).
+        max_response_bytes: 33554432
 proxy:
     http: ''
     https: ''
@@ -31,13 +99,62 @@ system:
     recovery_key: ''
     allow_modify_login_info: true
     disabled_adapters: []
+    blocking_executor:
+        # All asyncio.to_thread work shares this process-wide bounded pool.
+        # Both running threads and queued calls are capped to prevent tenant
+        # bursts from creating an unbounded queue of retained request objects.
+        max_workers: 8
+        max_pending: 128
+        # One trusted Workspace can occupy at most this many running + queued
+        # slots. This must not exceed half of max_workers.
+        max_inflight_per_scope: 4
+    # Public outbound IP addresses of this LangBot deployment. Some platforms
+    # (e.g. WeCom, WeChat Official Account, QQ Official API) require the
+    # caller's IPs to be added to their trusted-IP / IP-whitelist settings.
+    # When set, the web UI shows these IPs on the bot config form of such
+    # adapters. Also settable via the SYSTEM__OUTBOUND_IPS env var
+    # (comma-separated). Empty list = hidden in the web UI.
+    outbound_ips: []
     limitation:
         max_bots: -1
         max_pipelines: -1
         max_extensions: -1
+        max_knowledge_bases: -1
+        # When set to a non-empty string, every pipeline is forced to use this
+        # Box sandbox-scope template regardless of its own configuration, and
+        # the per-pipeline "Sandbox Scope" selector is locked in the web UI.
+        # Used by SaaS deployments to confine a tenant to a single shared
+        # sandbox (set to '{global}'). Empty string = no restriction.
+        force_box_session_id_template: ''
     task_retention:
-        # メモリ内に保持する完了済み非同期タスク履歴の最大数
+        # Keep at most this many completed async task records in memory
         completed_limit: 200
+        # Bound progress output retained by one task, including running tasks.
+        max_log_chars: 200000
+        # Protect the shared process from user-triggered operation storms.
+        max_active_user_tasks: 256
+        max_active_user_tasks_per_workspace: 8
+    session_retention:
+        # Process-local conversation sessions are a cache, not durable history.
+        max_entries: 2000
+        max_entries_per_workspace: 200
+        idle_ttl_seconds: 86400
+        max_conversations_per_session: 20
+        max_messages_per_conversation: 100
+    websocket_retention:
+        # Bound live browser sockets and per-Workspace fan-out in the shared process.
+        max_connections: 1024
+        max_connections_per_workspace: 32
+        # Idle proxy runtimes are evicted when this process-local cache fills.
+        max_workspace_proxies: 1024
+        max_conversations_per_workspace: 200
+        max_messages_per_conversation: 100
+        conversation_idle_ttl_seconds: 86400
+        send_queue_size: 100
+    response_limits:
+        # Defense in depth for tenant-configured upstream providers.
+        max_generated_chars: 1048576
+        max_stream_chunks: 100000
     jwt:
         expire: 604800
         secret: ''
@@ -46,34 +163,59 @@ database:
     sqlite:
         path: 'data/langbot.db'
     postgresql:
+        # Optional SQLAlchemy URL (postgresql[+asyncpg]://...). When set, it
+        # overrides the structured fields and preserves TLS/query options.
+        url: ''
         host: '127.0.0.1'
         port: 5432
         user: 'postgres'
         password: 'postgres'
         database: 'postgres'
+        # One bounded pool is shared by business data and Cloud pgvector.
+        pool_size: 10
+        max_overflow: 10
+        pool_timeout_seconds: 30
+        pool_recycle_seconds: 1800
+        # Applied only to Cloud runtime connections. The one-shot release
+        # migration uses its operator connection without these short limits.
+        statement_timeout_ms: 60000
+        lock_timeout_ms: 5000
+        idle_in_transaction_session_timeout_ms: 60000
+    cloud_migration:
+        # `langbot migrate --cloud` reads an operator-only PostgreSQL DSN from
+        # this environment variable. The operator role must differ from the
+        # runtime role above; never put its password in this file or CLI args.
+        operator_dsn_env: 'LANGBOT_CLOUD_MIGRATION_DSN'
 vdb:
     use: chroma
+    # Bound process-local collection/index handles across all Workspaces.
+    runtime_cache_limit: 1024
     qdrant:
         url: ''
         host: localhost
         port: 6333
         api_key: ''
     seekdb:
-        mode: embedded  # 'embedded' または 'server'
-        # 組み込みモード設定:
+        mode: embedded  # 'embedded' or 'server'
+        # Embedded mode options:
         path: './data/seekdb'
         database: 'langbot'
-        # サーバーモード設定（mode='server' の場合）:
+        # Server mode options (used when mode='server'):
         host: 'localhost'
         port: 2881
         user: 'root'
         password: ''
-        tenant: ''  # OceanBase サーバー向けの任意項目
+        tenant: ''  # Optional, for OceanBase server
     milvus:
         uri: 'http://127.0.0.1:19530'
         token: ''
         db_name: ''
     pgvector:
+        # SaaS/shared-schema deployments reuse database.postgresql. OSS can
+        # keep this false when deliberately using an external pgvector DB.
+        use_business_database: false
+        # Release migrations create one partial ANN index per enabled value.
+        allowed_dimensions: [384, 512, 768, 1024, 1536]
         host: '127.0.0.1'
         port: 5433
         database: 'langbot'
@@ -81,107 +223,259 @@ vdb:
         password: 'postgres'
     valkey_search:
         host: 'localhost'
-        port: 6379
+        port: 6379            # integration tests use 6380 -> valkey/valkey-bundle:9.1.0
         db: 0
-        username: ''      # 任意（ACL ユーザー）
-        password: ''      # 任意（ACL / requirepass）、ログには記録されません
-        tls: false        # 任意、toB/SaaS 環境向け
-        index_algorithm: 'HNSW'    # HNSW（近似）または FLAT（厳密）
-        distance_metric: 'COSINE'  # COSINE、L2、または IP
-        request_timeout: 5000      # リクエストごとのタイムアウト（ミリ秒）
+        password: ''          # optional (toB auth)
+        username: ''          # optional (ACL user, toB)
+        tls: false            # optional (toB/SaaS)
+        index_algorithm: 'HNSW'   # HNSW | FLAT
+        distance_metric: 'COSINE' # COSINE | L2 | IP
+        request_timeout: 5000     # per-request timeout in ms (glide default 250ms is too low for KNN)
 storage:
     use: local
+    # Bound every object materialized into Core memory. Built-in Local/S3
+    # providers enforce this while reading (hard cap: 64 MiB).
+    max_object_read_bytes: 10485760
     cleanup:
-        # ローカル/S3 のアップロードファイルと古いログを定期的に削除するか
+        # Enable periodic cleanup of local/S3 uploaded files and old log files
         enabled: true
-        # クリーンアップ確認間隔（時間）
+        # Cleanup check interval in hours
         check_interval_hours: 1
-        # ストレージルート直下のアップロードファイルを保持する日数
+        # Root-level uploaded files older than this will be deleted
         uploaded_file_retention_days: 7
-        # LangBot ログファイルを保持する日数
+        # LangBot log files older than this many days will be deleted
         log_retention_days: 3
+        # Bound per-Workspace file cleanup and diagnostic candidate lists.
+        # Supports STORAGE__CLEANUP__MAX_FILES_PER_RUN (hard cap: 10000).
+        max_files_per_run: 1000
     s3:
         endpoint_url: ''
         access_key_id: ''
         secret_access_key: ''
         region: 'us-east-1'
         bucket: 'langbot-storage'
+        # boto3 is synchronous; bound the number of operations delegated to
+        # worker threads so an S3 slowdown cannot saturate the process.
+        max_concurrency: 16
 plugin:
     enable: true
     runtime_ws_url: 'ws://langbot_plugin_runtime:5400/control/ws'
     enable_marketplace: true
     display_plugin_debug_url: 'ws://localhost:5401/plugin/debug/ws'
+    worker:
+        # Instance-wide maximum for every plugin installation. Plugin
+        # manifests cannot raise or override these limits.
+        max_cpus: 1.0
+        max_memory_mb: 512
+        max_pids: 128
+        max_open_files: 256
+        max_file_size_mb: 512
+        # Instance-wide admission budgets. The effective worker count is the
+        # lowest of max_workers, max_total_cpus/max_cpus and
+        # max_total_memory_mb/max_memory_mb.
+        max_workers: 16
+        max_total_cpus: 8.0
+        max_total_memory_mb: 8192
+        # Includes disabled and historical installation fences retained to
+        # reject stale desired-state replay.
+        max_installations: 10000
+        # Restart storms are globally serialized by default. Repeated
+        # unexpected exits within the configured window open a Runtime-wide
+        # circuit; one half-open probe must remain stable before other
+        # installations may restart.
+        max_concurrent_restarts: 1
+        restart_failure_threshold: 8
+        restart_failure_window_seconds: 30.0
+        restart_circuit_open_seconds: 60.0
+        # Cloud shared Runtime sets this to true and fails closed unless
+        # delegated cgroup v2 controllers are available.
+        require_hard_limits: false
     binary_storage:
-        # 1 つのプラグインバイナリストレージ値の最大バイト数
+        # Max bytes for a single plugin binary storage value
         max_value_bytes: 10485760
-monitoring:
-    auto_cleanup:
-        # 期限切れの監視レコードを自動削除するか
+mcp:
+    # Bound instance-wide MCP startup and shutdown bursts. Supports
+    # MCP__LIFECYCLE_CONCURRENCY and is clamped to a maximum of 128.
+    lifecycle_concurrency: 16
+    stdio:
+        # Independent gate for local stdio MCP transports. Cloud v2 sets
+        # MCP__STDIO__ENABLED=false even when Box Runtime is available.
         enabled: true
-        # 監視レコードの保持日数
+monitoring:
+    query_limits:
+        # Maximum records materialized by one paginated monitoring request.
+        # Supports MONITORING__QUERY_LIMITS__PAGE_ROWS (hard cap: 5000).
+        page_rows: 1000
+        # CSV exports are currently assembled in memory. Keep this lower than
+        # the historical 100000-row default (hard cap: 50000).
+        export_rows: 10000
+        # Maximum related records returned by one session/message detail view
+        # (hard cap: 10000). Aggregate statistics remain database-computed.
+        detail_rows: 2000
+        # Token charts are grouped in SQL and return only the newest buckets
+        # (hard cap: 10000). Supports an environment variable override.
+        timeseries_buckets: 1000
+        # Bound high-offset scans that can otherwise monopolize PostgreSQL CPU
+        # (hard cap: 10000000).
+        max_offset: 1000000
+    auto_cleanup:
+        # Enable automatic cleanup of expired monitoring records
+        enabled: true
+        # Retention period in days, records older than this will be deleted
         retention_days: 30
-        # クリーンアップ確認間隔（時間）
+        # Cleanup check interval in hours
         check_interval_hours: 1
-        # 各監視テーブルで 1 回に削除する期限切れ行数
+        # Number of expired rows to delete per table batch
         delete_batch_size: 1000
+        # Prevent one large Workspace backlog from monopolizing PostgreSQL.
+        # Supports MONITORING__AUTO_CLEANUP__MAX_BATCHES_PER_TABLE_PER_RUN.
+        max_batches_per_table_per_run: 4
 box:
-    backend: 'local'  # 'local' (Docker/nsjail), 'docker', 'nsjail', または 'e2b'。BOX__BACKEND で書き込めます。
+    # Master switch for the Box sandbox runtime. When false, LangBot does NOT
+    # attempt to connect to a remote Box runtime nor start a local stdio Box
+    # subprocess. Disabling Box also disables every feature that depends on it:
+    # the native sandbox tools (exec/read/write/edit/glob/grep), the activate
+    # skill tool, skill add/edit, and stdio-mode MCP servers. Skills can still
+    # be listed read-only and http/sse MCP servers continue to work.
+    enabled: true
+    backend: 'local'  # 'local' (Docker/nsjail), 'docker', 'nsjail', or 'e2b'. Can be written via BOX__BACKEND.
     runtime:
-        endpoint: ''  # 外部 Box Runtime ベース URL（例: 'ws://127.0.0.1:5410'）。空の場合はローカル自動管理ランタイムを使用。
+        # External WebSocket runtimes also require LANGBOT_BOX_CONTROL_TOKEN in
+        # both LangBot and Box. Keep the shared secret out of this config file.
+        endpoint: ''  # External Box Runtime base URL, e.g. 'ws://127.0.0.1:5410'. Leave empty for local auto-managed runtime.
+    limits:
+        max_sessions: 64
+        max_managed_processes: 64
+        max_completed_processes: 256
+        # Core scans a Workspace before and after quota-enforced executions.
+        # Fail closed instead of repeatedly walking an inode bomb.
+        # Supports BOX__LIMITS__MAX_WORKSPACE_ENTRIES (hard cap: 1000000).
+        max_workspace_entries: 100000
+        # Retained admission fences prevent replay after entitlement expiry or
+        # revocation. Fail closed before that monotonic state can grow without
+        # bound; Cloud may override this with BOX__LIMITS__MAX_ADMISSION_RECORDS.
+        max_admission_records: 100000
+        max_rpc_file_bytes: 20971520
+    # Cloud v2 overrides these values through the instance config/environment.
+    # OSS keeps admission disabled and preserves the existing multi-session
+    # local behavior. These limits are Runtime-owned and cannot be relaxed by
+    # a pipeline, Workspace entitlement, or tool call.
+    admission:
+        required: false
+        logical_session_id: 'global'
+        required_backend: 'nsjail'
+        max_sessions: 1
+        max_managed_processes: 0
+        max_grant_ttl_sec: 300
+        max_timeout_sec: 120
+        cpus: 1.0
+        memory_mb: 512
+        pids_limit: 128
+        read_only_rootfs: true
+        # OSS admission-disabled mode uses 0 for unlimited compatibility.
+        # Cloud bootstrap requires a positive hard quota.
+        workspace_quota_mb: 0
+        readiness_cache_sec: 15
     local:
         profile: 'default'
-        image: ''  # カスタムローカルサンドボックスイメージ。空の場合はプロファイルデフォルトを使用。
-        host_root: './data/box'  # ローカルワークスペースマウント用のホストルートディレクトリ。Docker デプロイ時は langbot_box にマウントする絶対ホストパスを使用。
-        default_workspace: ''  # デフォルトは '<host_root>/default'。
-        skills_root: 'skills'  # Box が管理する Skill パッケージディレクトリ。相対パスは host_root 配下に解決されます。
-        allowed_mount_roots:  # 空の場合はデフォルトで ['<host_root>']。
+        image: ''  # Custom local sandbox image. Leave empty to use the profile default.
+        host_root: './data/box'  # Base host directory for local workspace mounts. Docker deployments should override this with an absolute host path.
+        default_workspace: ''  # Defaults to '<host_root>/default'. Relative paths are resolved under host_root.
+        skills_root: 'skills'  # Box-owned skill package directory. Relative paths are resolved under host_root.
+        allowed_mount_roots:  # Defaults to ['<host_root>'] when left empty.
             - './data/box'
             - '/tmp'
-        workspace_quota_mb: null  # オプションのディスククォータオーバーライド (>= 0)。null = プロファイルデフォルト。
+        workspace_quota_mb: null  # Optional disk quota override (>= 0). null = profile default.
+    # Default nsjail cgroup memory limit for each MCP stdio server process, in MB.
+    # Node.js MCP servers (npx/bunx) need more memory than Python ones because V8
+    # and WebAssembly modules (e.g. undici llhttp) reserve large virtual address
+    # space at startup. Setting this too low causes processes to be killed with
+    # return_code=137 (OOM kill); the symptom is "Box managed process exited
+    # unexpectedly" in the logs.  Raise on machines with ample RAM; lower only if
+    # you run exclusively Python (uvx) MCP servers.
+    # Can also be set via BOX__DEFAULT_MEMORY_MB. Default: 1536.
+    default_memory_mb: 1536
     docker:
-        cpu_limit_enabled: true  # false の場合、Docker サンドボックスコンテナは --cpus なしで起動します。メモリと PID 制限は維持されます。
+        cpu_limit_enabled: true  # When false, Docker sandbox containers are started without --cpus. Memory and PID limits still apply.
     e2b:
-        api_key: ''  # E2B_API_KEY 環境変数でも設定可能。
-        api_url: ''  # セルフホストデプロイ用のカスタム API URL。
-        template: ''  # デフォルトテンプレート ID（例: 'base', 'python-3.11'）。
+        api_key: ''  # Can also be set via E2B_API_KEY env var.
+        api_url: ''  # Custom API URL for self-hosted deployments.
+        template: ''  # Default template ID (e.g. 'base', 'python-3.11').
 space:
-    # Space サービス URL
+    # Space service URL for OAuth and API
     url: 'https://space.langbot.app'
-    # Space モデルリクエスト API URL（MaaS）
+    # Space API URL for model requests (MaaS)
     models_gateway_api_url: 'https://api.langbot.cloud/v1'
-    # OAuth 認可ページ URL
+    # OAuth authorization page URL (user will be redirected here)
     oauth_authorize_url: 'https://space.langbot.app/auth/authorize'
     disable_models_service: false
     disable_telemetry: false
 ```
 
-## 補足
+## 設定グループの説明
 
-- `storage.cleanup.uploaded_file_retention_days` はストレージルート直下の一時アップロードファイルのみを削除します。プラグイン設定ファイルやディレクトリ配下の内部オブジェクトは削除しません。
-- `storage.cleanup.log_retention_days` はファイル名の日付に基づいて古いログを削除します。デフォルトでは最大 3 日分のログを保持します。
-- SQLite をデータベースとして使用している場合、監視レコードの自動削除後にデータベースファイルの空き容量を直接解放します。
-- `plugin.binary_storage.max_value_bytes` は 1 つのプラグインバイナリストレージ値のサイズを制限します。デフォルトは 10 MiB です。
-- WebUI のサイドバーには「ストレージ分析」ページがあり、データベース、ログ、アップロードファイル、ベクターストア、プラグイン、MCP、一時ファイル、クリーンアップ候補を確認できます。
-- `vdb.valkey_search` は [Valkey Search](https://valkey.io/) モジュールを公式の非同期クライアント `valkey-glide` 経由で利用し、ベクター検索・全文検索・ハイブリッド検索の 3 モードに対応します。モジュールを読み込んだサーバー（例: `valkey/valkey-bundle:9.1.0`、`docker run -d -p 6379:6379 valkey/valkey-bundle:9.1.0`）を起動してください。注意: ハイブリッド検索はフィルタ後に KNN を行うモデルのため、`vector_weight` パラメータは受け付けられますが**反映されません**（Valkey Search の原生的な制限）。接続は遅延確立されるため、サーバーが停止・誤設定でも起動を妨げません。詳細は [Valkey Search 統合ドキュメント](https://github.com/langbot-app/LangBot/blob/master/docs/VALKEY_SEARCH_INTEGRATION.md) を参照してください。
-- `api.global_api_key` はエージェント / 自動化向けのグローバル API キーです。設定すると、HTTP API または組み込み MCP サーバー（`/mcp`）の呼び出し時に `X-API-Key: <key>` または `Authorization: Bearer *** を送るだけで認証されます（ログインセッションやデータベース保存の `lbk_` キーは不要）。`config.yaml` に平文で保存されるため、信頼できる / 内部デプロイでのみ有効化し、HTTPS で公開してください。[API キー認証](https://github.com/langbot-app/LangBot/blob/master/docs/API_KEY_AUTH.md) を参照。
+### API、WebUI、招待
 
-## 環境変数による設定
+- `api.port` は HTTP API と WebUI のポートです。`api.webhook_prefix` はプラットフォームのコールバック URL を生成する公開ベース URL で、本番環境では通常 HTTPS リバースプロキシのオリジンを指定します。
+- WebUI と API のオリジンが異なる場合は `api.webui_url` を設定します。OAuth リダイレクトはこのサーバー側設定と `webhook_prefix` のみを信頼し、リクエストの `Host` / `Origin` ヘッダーは信頼しません。
+- `api.global_api_key` は `X-API-Key` または `Authorization: Bearer` で HTTP Service API と組み込み MCP サーバーを認証します。ログインセッションや DB 保存の `lbk_` キーは不要で、空文字列は無効を意味します。
+- `workspace.invitations.public_web_url` は招待リンクの公開 URL です。空の場合は `api.webui_url`、次に `api.webhook_prefix` へフォールバックします。メール配信は `resend` または `smtp` を選び、`provider` が空ならリンクのみを生成します。
 
-`config.yaml` の設定は環境変数を介して設定できます。環境変数名は大文字で、二重アンダースコアで接続されます。例: `API__PORT` は `api.port` を表します。
+<Warning>
+グローバル API キー、JWT シークレット、DB/S3 認証情報、メールプロバイダーのシークレット、E2B キーは機密情報です。本番では環境変数を優先し、実値を Git にコミットせず、認証対象のエンドポイントは HTTPS で公開してください。
+</Warning>
 
-- `API__PORT` は `api.port` を表します
-- `CONCURRENCY__PIPELINE` は `concurrency.pipeline` を表します
-- `DATABASE__SQLITE__PATH` は `database.sqlite.path` を表します
-- `STORAGE__CLEANUP__UPLOADED_FILE_RETENTION_DAYS` は `storage.cleanup.uploaded_file_retention_days` を表します
-- `STORAGE__CLEANUP__LOG_RETENTION_DAYS` は `storage.cleanup.log_retention_days` を表します
-- `MONITORING__AUTO_CLEANUP__RETENTION_DAYS` は `monitoring.auto_cleanup.retention_days` を表します
-- `PLUGIN__BINARY_STORAGE__MAX_VALUE_BYTES` は `plugin.binary_storage.max_value_bytes` を表します
-- `BOX__BACKEND` は `box.backend` を表します
-- `BOX__LOCAL__HOST_ROOT` は `box.local.host_root` を表します
-- `BOX__LOCAL__SKILLS_ROOT` は `box.local.skills_root` を表します
+### 受付・容量制限
 
-起動時、LangBot はすべての環境変数を読み取り、対応する設定を `config.yaml` に適用して `data/config.yaml` ファイルに書き込みます。
+- `concurrency` は実行中・待機中のパイプライン処理をインスタンス全体および Workspace 単位で制限します。
+- `webhooks` は Workspace ごとの有効な宛先数とインスタンス全体の送信中リクエスト数を制限します。
+- `cloud.directory` は 1 つの Cloud 論理インスタンスに対する運用上の安全上限であり、サブスクリプション権限ではありません。上限超過の権威ディレクトリ更新は切り捨てず、全体を拒否します。通常のセルフホストでは既定値を維持してください。
+- `system.blocking_executor`、各 `*_retention`、`response_limits` はスレッド、キャッシュ、ソケット、上流レスポンスのメモリ使用を有界にします。
+- `system.limitation` の `-1` は無制限です。`force_box_session_id_template` は SaaS のサンドボックス制約用で、通常のセルフホストでは空のままにします。
+
+### データベースとベクトルストア
+
+- `database.use` で SQLite または PostgreSQL を選択します。`database.postgresql.url` が空でなければ分割された接続項目より優先され、TLS/クエリオプションも保持できます。
+- PostgreSQL のプールとタイムアウトは共有ランタイム資源を制限します。`database.cloud_migration.operator_dsn_env` は運用者専用のマイグレーション DSN を格納する環境変数名で、ランタイムロールとは分離してください。
+- `vdb.use` で利用するベクトルバックエンドを選びます。実際に選択したバックエンドだけを設定します。
+- `vdb.pgvector.use_business_database` は `database.postgresql` を再利用します。`allowed_dimensions` はリリースマイグレーションが作成する ANN インデックスの次元を制御します。
+- Valkey Search には Search モジュール入りの Valkey（例: `valkey/valkey-bundle:9.1.0`）が必要です。
+
+### ストレージ、プラグイン、MCP、監視
+
+- `storage.max_object_read_bytes` は Core のメモリへ読み込む 1 オブジェクトの上限です。クリーンアップ項目は 1 回のファイル走査量を、`s3.max_concurrency` はワーカースレッドへ委譲する boto3 操作数を制限します。
+- `plugin.worker` は各インストールとインスタンス全体のハード上限です。プラグイン manifest から緩和できません。再起動関連項目は Runtime の再起動ストームを抑制します。
+- `mcp.lifecycle_concurrency` は MCP の起動・停止バーストを制限します。`mcp.stdio.enabled` は HTTP/SSE MCP を維持したままローカル stdio MCP だけを無効化できます。
+- `monitoring.query_limits` と `auto_cleanup` は大きなページ、CSV、offset、古いレコードがメモリや PostgreSQL を独占しないようにします。
+
+### Box サンドボックス
+
+- `box.enabled` は総合スイッチです。無効にするとネイティブサンドボックスツール、Skill の追加/編集、stdio MCP も無効になりますが、読み取り専用 Skill 一覧と HTTP/SSE MCP は利用できます。
+- `box.backend` は `local`、`docker`、`nsjail`、`e2b` から選び、`runtime.endpoint` は外部 WebSocket Runtime への接続に使います。
+- `box.limits` はセッション、プロセス、Workspace 走査、保持する受付フェンス、RPC ファイルサイズを制限します。
+- `box.admission` は Cloud v2 の強制受付ポリシーです。OSS の既定値は `required: false` で、パイプラインや Workspace 権限、ツール呼び出しから Runtime 所有の上限を緩和できません。
+- Docker では `box.local.host_root` に Box コンテナからマウント可能な絶対ホストパスを指定します。
+- `box.default_memory_mb` は各 stdio MCP プロセスの nsjail cgroup メモリ既定値です。Node.js MCP は Python MCP より多く必要になりやすく、低すぎる場合は終了コード `137` がよく発生します。
+
+### LangBot Space
+
+`space.url`、`models_gateway_api_url`、`oauth_authorize_url` は Space OAuth/API と MaaS の接続先です。2 つの `disable_*` でモデルサービスとテレメトリーを個別に無効化できます。
+
+## 環境変数による上書き
+
+ネストしたキーを大文字にし、階層を二重アンダースコアで連結します。
+
+- `API__PORT` → `api.port`
+- `WORKSPACE__INVITATIONS__PUBLIC_WEB_URL` → `workspace.invitations.public_web_url`
+- `CONCURRENCY__PENDING_QUERIES_PER_WORKSPACE` → `concurrency.pending_queries_per_workspace`
+- `DATABASE__POSTGRESQL__POOL_SIZE` → `database.postgresql.pool_size`
+- `STORAGE__CLEANUP__MAX_FILES_PER_RUN` → `storage.cleanup.max_files_per_run`
+- `PLUGIN__WORKER__MAX_TOTAL_MEMORY_MB` → `plugin.worker.max_total_memory_mb`
+- `MCP__STDIO__ENABLED` → `mcp.stdio.enabled`
+- `BOX__DEFAULT_MEMORY_MB` → `box.default_memory_mb`
+
+起動時に LangBot が環境変数を適用し、結果を `data/config.yaml` に書き込みます。
 
 <Note>
-Box 関連設定は `langbot` サービスに統一形式の `BOX__*` 環境変数で設定します。LangBot は起動時にそれらを `data/config.yaml` に適用し、INIT RPC 経由で Box 設定を `langbot_box` に渡します。`LANGBOT_BOX_*` や `BOX__*` を `langbot_box` に設定しても直接読み取られません。
+Docker では統一された `BOX__*` 環境変数を `langbot` サービスに設定してください。LangBot は INIT RPC で Box 設定を `langbot_box` へ渡すため、`langbot_box` に直接設定した変数は読み取られません。
 </Note>

--- a/zh/deploy/settings.mdx
+++ b/zh/deploy/settings.mdx
@@ -1,18 +1,57 @@
 ---
 title: "系统环境设置"
-description: "配置 LangBot 系统环境变量与运行时设置，定制你的 AI 机器人部署。"
+description: "完整说明 LangBot config.yaml 的 API、并发、数据库、向量库、存储、插件、MCP、监控与 Box 配置。"
 ---
 
-配置系统运行的一些环境信息，文件位于 `data/config.yaml`。
-一般不需要修改。
+LangBot 的运行配置位于 `data/config.yaml`。首次启动会从默认模板生成该文件；下面的示例与 LangBot 仓库中的 [`src/langbot/templates/config.yaml`](https://github.com/langbot-app/LangBot/blob/master/src/langbot/templates/config.yaml) 保持一致。
+
+<Info>
+大多数自部署用户只需要关注公网地址、数据库/向量库、对象存储与 Box Runtime。未理解用途的容量和 Cloud 安全上限建议保持默认值。
+</Info>
+
+## 完整默认配置
 
 ```yaml
-admins: []
 api:
     port: 5300
     webhook_prefix: 'http://127.0.0.1:5300'
     extra_webhook_prefix: ''
-    global_api_key: ''  # 全局 API Key。非空时即可直接用于 HTTP API 与 MCP 服务（/mcp）鉴权，无需登录态、无需数据库记录、无需 lbk_ 前缀；留空则关闭。明文存储，仅在可信/内网部署启用并配合 HTTPS。
+    # Canonical browser origin when WebUI and API use different origins in
+    # development (for example http://localhost:3000). Production bundled UI
+    # may leave this empty when webhook_prefix already has the browser origin.
+    # OAuth redirects trust only these server-side values, never request Host
+    # or Origin headers.
+    webui_url: ''
+    # Global API key for the HTTP service API and the MCP server. When set to a
+    # non-empty string, this key is accepted anywhere a web-UI-created API key is
+    # accepted (X-API-Key header or "Authorization: Bearer <key>"), WITHOUT any
+    # login session and without a database record. Leave empty to disable.
+    # Keep this value secret; only enable it on trusted/internal deployments.
+    global_api_key: ''
+workspace:
+    invitations:
+        # Public WebUI origin used to build invitation links. Leave empty to
+        # use api.webui_url, then api.webhook_prefix. Set via
+        # WORKSPACE__INVITATIONS__PUBLIC_WEB_URL in container deployments.
+        public_web_url: ''
+        email:
+            # Optional invitation email delivery. Empty provider keeps
+            # invitations link-only. Supported: resend, smtp.
+            provider: ''
+            from: ''
+            timeout_seconds: 10
+            resend:
+                api_url: 'https://api.resend.com/emails'
+                # Secret. Set via WORKSPACE__INVITATIONS__EMAIL__RESEND__API_KEY.
+                api_key: ''
+            smtp:
+                host: ''
+                port: 587
+                username: ''
+                # Secret. Set via WORKSPACE__INVITATIONS__EMAIL__SMTP__PASSWORD.
+                password: ''
+                starttls: true
+                ssl: false
 command:
     enable: true
     prefix:
@@ -22,6 +61,35 @@ command:
 concurrency:
     pipeline: 20
     session: 1
+    # Hard admission limits for queued + running pipeline queries.
+    pending_queries: 1000
+    pending_queries_per_workspace: 100
+webhooks:
+    # Bound database materialization and per-message outbound fan-out.
+    # Existing rows above this limit remain deletable through the management
+    # API, but only this many enabled destinations are dispatched.
+    # Supports WEBHOOKS__MAX_PER_WORKSPACE (hard cap: 64).
+    max_per_workspace: 16
+    # Instance-wide request admission. Delivery fails open when every slot is
+    # occupied instead of retaining an unbounded queue of webhook tasks.
+    # Supports WEBHOOKS__MAX_INFLIGHT_REQUESTS (hard cap: 128).
+    max_inflight_requests: 16
+cloud:
+    # Operational safety ceilings for the one logical Cloud instance. These
+    # are not subscription entitlements. An authoritative directory update
+    # that would exceed them is rejected atomically rather than truncated.
+    directory:
+        # Tune downward from the measured production capacity curve. Core has
+        # an absolute safety ceiling of 5,000 active Workspaces.
+        max_active_workspaces: 1000
+        # Full snapshots contain current Workspaces only. Archived tombstones
+        # are delivered through bounded per-Workspace deltas.
+        max_snapshot_workspaces: 1000
+        # Aggregate memberships accepted in one signed snapshot or delta.
+        max_snapshot_memberships: 20000
+        # Signed control-plane envelope buffered by the closed adapter before
+        # JSON/JWS verification (32 MiB; absolute maximum 64 MiB).
+        max_response_bytes: 33554432
 proxy:
     http: ''
     https: ''
@@ -31,13 +99,62 @@ system:
     recovery_key: ''
     allow_modify_login_info: true
     disabled_adapters: []
+    blocking_executor:
+        # All asyncio.to_thread work shares this process-wide bounded pool.
+        # Both running threads and queued calls are capped to prevent tenant
+        # bursts from creating an unbounded queue of retained request objects.
+        max_workers: 8
+        max_pending: 128
+        # One trusted Workspace can occupy at most this many running + queued
+        # slots. This must not exceed half of max_workers.
+        max_inflight_per_scope: 4
+    # Public outbound IP addresses of this LangBot deployment. Some platforms
+    # (e.g. WeCom, WeChat Official Account, QQ Official API) require the
+    # caller's IPs to be added to their trusted-IP / IP-whitelist settings.
+    # When set, the web UI shows these IPs on the bot config form of such
+    # adapters. Also settable via the SYSTEM__OUTBOUND_IPS env var
+    # (comma-separated). Empty list = hidden in the web UI.
+    outbound_ips: []
     limitation:
         max_bots: -1
         max_pipelines: -1
         max_extensions: -1
+        max_knowledge_bases: -1
+        # When set to a non-empty string, every pipeline is forced to use this
+        # Box sandbox-scope template regardless of its own configuration, and
+        # the per-pipeline "Sandbox Scope" selector is locked in the web UI.
+        # Used by SaaS deployments to confine a tenant to a single shared
+        # sandbox (set to '{global}'). Empty string = no restriction.
+        force_box_session_id_template: ''
     task_retention:
-        # 内存中最多保留的已完成异步任务记录数量
+        # Keep at most this many completed async task records in memory
         completed_limit: 200
+        # Bound progress output retained by one task, including running tasks.
+        max_log_chars: 200000
+        # Protect the shared process from user-triggered operation storms.
+        max_active_user_tasks: 256
+        max_active_user_tasks_per_workspace: 8
+    session_retention:
+        # Process-local conversation sessions are a cache, not durable history.
+        max_entries: 2000
+        max_entries_per_workspace: 200
+        idle_ttl_seconds: 86400
+        max_conversations_per_session: 20
+        max_messages_per_conversation: 100
+    websocket_retention:
+        # Bound live browser sockets and per-Workspace fan-out in the shared process.
+        max_connections: 1024
+        max_connections_per_workspace: 32
+        # Idle proxy runtimes are evicted when this process-local cache fills.
+        max_workspace_proxies: 1024
+        max_conversations_per_workspace: 200
+        max_messages_per_conversation: 100
+        conversation_idle_ttl_seconds: 86400
+        send_queue_size: 100
+    response_limits:
+        # Defense in depth for tenant-configured upstream providers.
+        max_generated_chars: 1048576
+        max_stream_chunks: 100000
     jwt:
         expire: 604800
         secret: ''
@@ -46,34 +163,59 @@ database:
     sqlite:
         path: 'data/langbot.db'
     postgresql:
+        # Optional SQLAlchemy URL (postgresql[+asyncpg]://...). When set, it
+        # overrides the structured fields and preserves TLS/query options.
+        url: ''
         host: '127.0.0.1'
         port: 5432
         user: 'postgres'
         password: 'postgres'
         database: 'postgres'
+        # One bounded pool is shared by business data and Cloud pgvector.
+        pool_size: 10
+        max_overflow: 10
+        pool_timeout_seconds: 30
+        pool_recycle_seconds: 1800
+        # Applied only to Cloud runtime connections. The one-shot release
+        # migration uses its operator connection without these short limits.
+        statement_timeout_ms: 60000
+        lock_timeout_ms: 5000
+        idle_in_transaction_session_timeout_ms: 60000
+    cloud_migration:
+        # `langbot migrate --cloud` reads an operator-only PostgreSQL DSN from
+        # this environment variable. The operator role must differ from the
+        # runtime role above; never put its password in this file or CLI args.
+        operator_dsn_env: 'LANGBOT_CLOUD_MIGRATION_DSN'
 vdb:
     use: chroma
+    # Bound process-local collection/index handles across all Workspaces.
+    runtime_cache_limit: 1024
     qdrant:
         url: ''
         host: localhost
         port: 6333
         api_key: ''
     seekdb:
-        mode: embedded  # 'embedded' 或 'server'
-        # 嵌入式模式配置：
+        mode: embedded  # 'embedded' or 'server'
+        # Embedded mode options:
         path: './data/seekdb'
         database: 'langbot'
-        # 服务器模式配置（mode='server' 时生效）：
+        # Server mode options (used when mode='server'):
         host: 'localhost'
         port: 2881
         user: 'root'
         password: ''
-        tenant: ''  # 可选，用于 OceanBase 多租户场景
+        tenant: ''  # Optional, for OceanBase server
     milvus:
         uri: 'http://127.0.0.1:19530'
         token: ''
         db_name: ''
     pgvector:
+        # SaaS/shared-schema deployments reuse database.postgresql. OSS can
+        # keep this false when deliberately using an external pgvector DB.
+        use_business_database: false
+        # Release migrations create one partial ANN index per enabled value.
+        allowed_dimensions: [384, 512, 768, 1024, 1536]
         host: '127.0.0.1'
         port: 5433
         database: 'langbot'
@@ -81,110 +223,296 @@ vdb:
         password: 'postgres'
     valkey_search:
         host: 'localhost'
-        port: 6379
+        port: 6379            # integration tests use 6380 -> valkey/valkey-bundle:9.1.0
         db: 0
-        username: ''      # 可选（ACL 用户）
-        password: ''      # 可选（ACL / requirepass），不会记录到日志
-        tls: false        # 可选，用于 toB/SaaS 场景
-        index_algorithm: 'HNSW'    # HNSW（近似）或 FLAT（精确）
-        distance_metric: 'COSINE'  # COSINE、L2 或 IP
-        request_timeout: 5000      # 单次请求超时时间（毫秒）
+        password: ''          # optional (toB auth)
+        username: ''          # optional (ACL user, toB)
+        tls: false            # optional (toB/SaaS)
+        index_algorithm: 'HNSW'   # HNSW | FLAT
+        distance_metric: 'COSINE' # COSINE | L2 | IP
+        request_timeout: 5000     # per-request timeout in ms (glide default 250ms is too low for KNN)
 storage:
     use: local
+    # Bound every object materialized into Core memory. Built-in Local/S3
+    # providers enforce this while reading (hard cap: 64 MiB).
+    max_object_read_bytes: 10485760
     cleanup:
-        # 是否定期清理本地/S3 上传文件和旧日志文件
+        # Enable periodic cleanup of local/S3 uploaded files and old log files
         enabled: true
-        # 清理检查间隔，单位为小时
+        # Cleanup check interval in hours
         check_interval_hours: 1
-        # 超过此天数的根目录上传文件会被删除
+        # Root-level uploaded files older than this will be deleted
         uploaded_file_retention_days: 7
-        # 最多保留此天数内的 LangBot 日志文件
+        # LangBot log files older than this many days will be deleted
         log_retention_days: 3
+        # Bound per-Workspace file cleanup and diagnostic candidate lists.
+        # Supports STORAGE__CLEANUP__MAX_FILES_PER_RUN (hard cap: 10000).
+        max_files_per_run: 1000
     s3:
         endpoint_url: ''
         access_key_id: ''
         secret_access_key: ''
         region: 'us-east-1'
         bucket: 'langbot-storage'
+        # boto3 is synchronous; bound the number of operations delegated to
+        # worker threads so an S3 slowdown cannot saturate the process.
+        max_concurrency: 16
 plugin:
     enable: true
     runtime_ws_url: 'ws://langbot_plugin_runtime:5400/control/ws'
     enable_marketplace: true
     display_plugin_debug_url: 'ws://localhost:5401/plugin/debug/ws'
+    worker:
+        # Instance-wide maximum for every plugin installation. Plugin
+        # manifests cannot raise or override these limits.
+        max_cpus: 1.0
+        max_memory_mb: 512
+        max_pids: 128
+        max_open_files: 256
+        max_file_size_mb: 512
+        # Instance-wide admission budgets. The effective worker count is the
+        # lowest of max_workers, max_total_cpus/max_cpus and
+        # max_total_memory_mb/max_memory_mb.
+        max_workers: 16
+        max_total_cpus: 8.0
+        max_total_memory_mb: 8192
+        # Includes disabled and historical installation fences retained to
+        # reject stale desired-state replay.
+        max_installations: 10000
+        # Restart storms are globally serialized by default. Repeated
+        # unexpected exits within the configured window open a Runtime-wide
+        # circuit; one half-open probe must remain stable before other
+        # installations may restart.
+        max_concurrent_restarts: 1
+        restart_failure_threshold: 8
+        restart_failure_window_seconds: 30.0
+        restart_circuit_open_seconds: 60.0
+        # Cloud shared Runtime sets this to true and fails closed unless
+        # delegated cgroup v2 controllers are available.
+        require_hard_limits: false
     binary_storage:
-        # 单个插件二进制存储值的最大字节数
+        # Max bytes for a single plugin binary storage value
         max_value_bytes: 10485760
-monitoring:
-    auto_cleanup:
-        # 是否自动清理过期监控记录
+mcp:
+    # Bound instance-wide MCP startup and shutdown bursts. Supports
+    # MCP__LIFECYCLE_CONCURRENCY and is clamped to a maximum of 128.
+    lifecycle_concurrency: 16
+    stdio:
+        # Independent gate for local stdio MCP transports. Cloud v2 sets
+        # MCP__STDIO__ENABLED=false even when Box Runtime is available.
         enabled: true
-        # 监控记录保留天数，超过此天数的记录会被删除
+monitoring:
+    query_limits:
+        # Maximum records materialized by one paginated monitoring request.
+        # Supports MONITORING__QUERY_LIMITS__PAGE_ROWS (hard cap: 5000).
+        page_rows: 1000
+        # CSV exports are currently assembled in memory. Keep this lower than
+        # the historical 100000-row default (hard cap: 50000).
+        export_rows: 10000
+        # Maximum related records returned by one session/message detail view
+        # (hard cap: 10000). Aggregate statistics remain database-computed.
+        detail_rows: 2000
+        # Token charts are grouped in SQL and return only the newest buckets
+        # (hard cap: 10000). Supports an environment variable override.
+        timeseries_buckets: 1000
+        # Bound high-offset scans that can otherwise monopolize PostgreSQL CPU
+        # (hard cap: 10000000).
+        max_offset: 1000000
+    auto_cleanup:
+        # Enable automatic cleanup of expired monitoring records
+        enabled: true
+        # Retention period in days, records older than this will be deleted
         retention_days: 30
-        # 清理检查间隔，单位为小时
+        # Cleanup check interval in hours
         check_interval_hours: 1
-        # 每个监控表单批删除的过期记录数量
+        # Number of expired rows to delete per table batch
         delete_batch_size: 1000
+        # Prevent one large Workspace backlog from monopolizing PostgreSQL.
+        # Supports MONITORING__AUTO_CLEANUP__MAX_BATCHES_PER_TABLE_PER_RUN.
+        max_batches_per_table_per_run: 4
 box:
-    enabled: true  # Box Runtime 总开关。false 时禁用沙箱、Skill 添加/编辑和 stdio MCP 等依赖 Box 的功能。
-    backend: 'local'  # 'local' (Docker/nsjail), 'docker', 'nsjail', 或 'e2b'。可通过 BOX__BACKEND 写入。
+    # Master switch for the Box sandbox runtime. When false, LangBot does NOT
+    # attempt to connect to a remote Box runtime nor start a local stdio Box
+    # subprocess. Disabling Box also disables every feature that depends on it:
+    # the native sandbox tools (exec/read/write/edit/glob/grep), the activate
+    # skill tool, skill add/edit, and stdio-mode MCP servers. Skills can still
+    # be listed read-only and http/sse MCP servers continue to work.
+    enabled: true
+    backend: 'local'  # 'local' (Docker/nsjail), 'docker', 'nsjail', or 'e2b'. Can be written via BOX__BACKEND.
     runtime:
-        endpoint: ''  # 外部 Box Runtime 基础 URL，如 'ws://127.0.0.1:5410'。留空时，非 Docker 部署使用本地自动管理的 Runtime；Docker 部署连接 Compose 网络中的 langbot_box:5410。
+        # External WebSocket runtimes also require LANGBOT_BOX_CONTROL_TOKEN in
+        # both LangBot and Box. Keep the shared secret out of this config file.
+        endpoint: ''  # External Box Runtime base URL, e.g. 'ws://127.0.0.1:5410'. Leave empty for local auto-managed runtime.
+    limits:
+        max_sessions: 64
+        max_managed_processes: 64
+        max_completed_processes: 256
+        # Core scans a Workspace before and after quota-enforced executions.
+        # Fail closed instead of repeatedly walking an inode bomb.
+        # Supports BOX__LIMITS__MAX_WORKSPACE_ENTRIES (hard cap: 1000000).
+        max_workspace_entries: 100000
+        # Retained admission fences prevent replay after entitlement expiry or
+        # revocation. Fail closed before that monotonic state can grow without
+        # bound; Cloud may override this with BOX__LIMITS__MAX_ADMISSION_RECORDS.
+        max_admission_records: 100000
+        max_rpc_file_bytes: 20971520
+    # Cloud v2 overrides these values through the instance config/environment.
+    # OSS keeps admission disabled and preserves the existing multi-session
+    # local behavior. These limits are Runtime-owned and cannot be relaxed by
+    # a pipeline, Workspace entitlement, or tool call.
+    admission:
+        required: false
+        logical_session_id: 'global'
+        required_backend: 'nsjail'
+        max_sessions: 1
+        max_managed_processes: 0
+        max_grant_ttl_sec: 300
+        max_timeout_sec: 120
+        cpus: 1.0
+        memory_mb: 512
+        pids_limit: 128
+        read_only_rootfs: true
+        # OSS admission-disabled mode uses 0 for unlimited compatibility.
+        # Cloud bootstrap requires a positive hard quota.
+        workspace_quota_mb: 0
+        readiness_cache_sec: 15
     local:
         profile: 'default'
-        image: ''  # 自定义本地沙箱镜像。留空使用 profile 默认值。
-        host_root: './data/box'  # 本地工作区挂载的主机根目录。Docker 部署时应使用可被 langbot_box 挂载的绝对主机路径。
-        default_workspace: ''  # 默认为 '<host_root>/default'。
-        skills_root: 'skills'  # Box 管理的 Skill 包目录。相对路径会解析到 host_root 下。
-        allowed_mount_roots:  # 默认为 ['<host_root>']。
+        image: ''  # Custom local sandbox image. Leave empty to use the profile default.
+        host_root: './data/box'  # Base host directory for local workspace mounts. Docker deployments should override this with an absolute host path.
+        default_workspace: ''  # Defaults to '<host_root>/default'. Relative paths are resolved under host_root.
+        skills_root: 'skills'  # Box-owned skill package directory. Relative paths are resolved under host_root.
+        allowed_mount_roots:  # Defaults to ['<host_root>'] when left empty.
             - './data/box'
             - '/tmp'
-        workspace_quota_mb: null  # 可选磁盘配额上限（>=0）。null=套餐默认值。
-    default_memory_mb: 1536  # 每个 MCP stdio 进程的 nsjail cgroup 内存上限（MB）。Node.js 类 MCP（npx/bunx）因 V8+WASM 需要更多内存，过低会导致进程被 OOM 杀死（return_code=137）。可用 BOX__DEFAULT_MEMORY_MB 覆盖。  # 可选磁盘配额覆盖 (>= 0)。null 表示使用 profile 默认值。
+        workspace_quota_mb: null  # Optional disk quota override (>= 0). null = profile default.
+    # Default nsjail cgroup memory limit for each MCP stdio server process, in MB.
+    # Node.js MCP servers (npx/bunx) need more memory than Python ones because V8
+    # and WebAssembly modules (e.g. undici llhttp) reserve large virtual address
+    # space at startup. Setting this too low causes processes to be killed with
+    # return_code=137 (OOM kill); the symptom is "Box managed process exited
+    # unexpectedly" in the logs.  Raise on machines with ample RAM; lower only if
+    # you run exclusively Python (uvx) MCP servers.
+    # Can also be set via BOX__DEFAULT_MEMORY_MB. Default: 1536.
+    default_memory_mb: 1536
     docker:
-        cpu_limit_enabled: true  # false 时 Docker 沙箱容器不传 --cpus；内存和 PID 限制仍然生效。
+        cpu_limit_enabled: true  # When false, Docker sandbox containers are started without --cpus. Memory and PID limits still apply.
     e2b:
-        api_key: ''  # 也可通过 E2B_API_KEY 环境变量设置。
-        api_url: ''  # 自托管部署的自定义 API URL。
-        template: ''  # 默认模板 ID（如 'base', 'python-3.11'）。
+        api_key: ''  # Can also be set via E2B_API_KEY env var.
+        api_url: ''  # Custom API URL for self-hosted deployments.
+        template: ''  # Default template ID (e.g. 'base', 'python-3.11').
 space:
-    # Space 服务 URL
+    # Space service URL for OAuth and API
     url: 'https://space.langbot.app'
-    # Space 模型请求 API URL（MaaS）
+    # Space API URL for model requests (MaaS)
     models_gateway_api_url: 'https://api.langbot.cloud/v1'
-    # OAuth 授权页面 URL
+    # OAuth authorization page URL (user will be redirected here)
     oauth_authorize_url: 'https://space.langbot.app/auth/authorize'
     disable_models_service: false
     disable_telemetry: false
 ```
 
-## 配置说明
+## 配置分组说明
 
-- `storage.cleanup.uploaded_file_retention_days` 只清理存储根目录下的临时上传文件，不会清理插件配置文件或带目录的内部对象。
-- `storage.cleanup.log_retention_days` 按日志文件名中的日期清理旧日志，默认最多保留 3 天。
-- SQLite 作为数据库时，监控记录自动清理后会直接释放数据库文件空间。
-- `plugin.binary_storage.max_value_bytes` 用于限制插件单个二进制存储值大小，默认 10 MiB。
-- WebUI 侧边栏的“存储分析”页面可查看数据库、日志、上传文件、向量库、插件、MCP、临时文件等空间占用和清理候选项。
-- `vdb.valkey_search` 基于 [Valkey Search](https://valkey.io/) 模块，通过官方异步客户端 `valkey-glide` 接入，支持向量搜索、全文搜索和混合搜索三种模式。需要运行已加载该模块的服务，例如 `valkey/valkey-bundle:9.1.0`（`docker run -d -p 6379:6379 valkey/valkey-bundle:9.1.0`）。注意：混合搜索采用先过滤再 KNN 的模型，因此 `vector_weight` 参数虽被接受但**不会生效**（Valkey Search 原生限制）。连接为惰性建立，服务不可用或配置错误不会阻塞启动。详见 [Valkey Search 集成文档](https://github.com/langbot-app/LangBot/blob/master/docs/VALKEY_SEARCH_INTEGRATION.md)。
-- `api.global_api_key` 是面向 Agent / 自动化的全局 API Key：设置后，调用 HTTP API 或内置 MCP 服务（`/mcp`）时在请求头携带 `X-API-Key: <key>` 或 `Authorization: Bearer <key>` 即可鉴权，无需登录会话、无需在数据库中创建 `lbk_` 密钥。它是明文写在 `config.yaml` 中的，请仅在可信 / 内网环境启用，并通过 HTTPS 暴露。详见 [API Key 鉴权](https://github.com/langbot-app/LangBot/blob/master/docs/API_KEY_AUTH.md)。
+### API、WebUI 与成员邀请
+
+- `api.port`：LangBot HTTP API 与 WebUI 的监听端口，默认 `5300`。
+- `api.webhook_prefix`：对外可访问的服务地址，用于生成机器人平台的 Webhook 回调地址；生产环境通常应设置为反向代理后的 HTTPS 域名。
+- `api.extra_webhook_prefix`：需要同时展示第二个回调入口时使用，留空即不启用。
+- `api.webui_url`：WebUI 与 API 跨域部署时的浏览器端规范来源，例如开发环境的 `http://localhost:3000`。OAuth 回调只信任该配置与 `webhook_prefix`，不会信任请求中的 `Host` 或 `Origin` 请求头。
+- `api.global_api_key`：供自动化程序、HTTP Service API 和内置 MCP 服务使用的全局密钥。设置后可通过 `X-API-Key` 或 `Authorization: Bearer` 鉴权，无需登录会话或数据库中的 `lbk_` 密钥；留空表示关闭。
+- `workspace.invitations.public_web_url`：邀请链接使用的 WebUI 公网地址；留空时依次回退到 `api.webui_url`、`api.webhook_prefix`。
+- `workspace.invitations.email`：可选的邀请邮件发送配置。`provider` 支持 `resend`、`smtp`，留空时只生成邀请链接、不发送邮件。
+
+<Warning>
+`global_api_key`、JWT 密钥、数据库密码、S3 密钥、Resend/SMTP 密钥和 E2B API Key 都属于敏感信息。生产环境优先使用环境变量注入，不要提交到 Git，也不要通过明文 HTTP 暴露服务。
+</Warning>
+
+### 命令、并发与 Webhook 限制
+
+- `command`：控制命令系统是否启用、命令前缀以及权限映射。
+- `concurrency.pipeline`：实例同时处理的流水线请求数量；`concurrency.session`：同一会话允许的并发数量。
+- `concurrency.pending_queries` 与 `pending_queries_per_workspace`：限制“排队中 + 执行中”的请求总量，防止突发流量形成无限队列。
+- `webhooks.max_per_workspace`：每个 Workspace 最多调度的启用 Webhook 数量，硬上限为 `64`。
+- `webhooks.max_inflight_requests`：全实例同时发送的 Webhook 请求数，硬上限为 `128`；槽位占满时会快速失败，不会无限积压任务。
+
+### Cloud 目录安全上限
+
+`cloud.directory` 是单个 LangBot Cloud 逻辑实例的**运行安全上限**，不是套餐权益：
+
+- `max_active_workspaces`：允许加载的活跃 Workspace 数量，Core 绝对上限为 `5000`。
+- `max_snapshot_workspaces` / `max_snapshot_memberships`：一次签名目录快照允许携带的 Workspace 与成员关系数量。
+- `max_response_bytes`：签名控制面响应在验证前允许缓冲的最大字节数，默认 `32 MiB`、绝对上限 `64 MiB`。
+
+超过这些上限的权威目录更新会被整体拒绝，而不是静默截断。普通自部署用户通常不需要修改这一组。
+
+### 系统限制与内存保留
+
+- `system.instance_id`、`edition`、`recovery_key`：实例身份、发行版与恢复信息；除非部署流程明确要求，否则保持默认。
+- `system.disabled_adapters`：禁用的消息平台适配器列表。
+- `system.blocking_executor`：限制所有 `asyncio.to_thread` 工作共享的线程池、排队任务和单 Workspace 占用，防止阻塞调用拖垮进程。
+- `system.limitation`：实例级机器人、流水线、扩展、知识库数量限制；`-1` 表示不限制。`force_box_session_id_template` 用于 SaaS 强制统一沙箱作用域，普通自部署应保持空字符串。
+- `task_retention`：异步任务记录、日志字符数和用户主动任务并发上限。
+- `session_retention`：进程内会话缓存上限与空闲 TTL；它不是持久聊天记录。
+- `websocket_retention`：浏览器连接数、Workspace 代理缓存、对话缓存与发送队列上限。
+- `response_limits`：限制单次上游模型响应的字符数和流式分块数。
+- `system.jwt.expire` 以秒为单位；生产环境应显式设置不可预测的 `system.jwt.secret`。
+
+### 数据库与向量数据库
+
+- `database.use` 支持 `sqlite` 与 `postgresql`。SQLite 适合单机轻量部署；多实例或较高并发建议使用 PostgreSQL。
+- `database.postgresql.url` 非空时优先于拆分的 `host`、`port`、`user`、`password`、`database` 字段，并可保留 TLS 与查询参数。
+- PostgreSQL 的 `pool_size`、`max_overflow`、连接池超时与回收参数共同限制连接资源；三个数据库超时字段只应用于 Cloud 运行时连接。
+- `database.cloud_migration.operator_dsn_env` 指定 Cloud 发布迁移读取的运维级 DSN 环境变量。运维角色必须与运行时角色分离，密码不要写入配置文件或命令行参数。
+- `vdb.use` 选择向量后端。页面列出了 Qdrant、SeekDB、Milvus、pgvector 与 Valkey Search 的连接参数；只需要配置实际选中的后端。
+- `vdb.runtime_cache_limit` 限制进程内集合/索引句柄数量。
+- `vdb.pgvector.use_business_database: true` 表示复用 `database.postgresql`；`allowed_dimensions` 限定发布迁移创建 ANN 索引的向量维度。
+- `vdb.valkey_search` 需要带 Search 模块的 Valkey 服务，例如 `valkey/valkey-bundle:9.1.0`。连接按需建立，支持 HNSW/FLAT 与 COSINE/L2/IP。
+
+### 存储、插件、MCP 与监控
+
+- `storage.use` 选择本地或 S3 存储；`max_object_read_bytes` 限制一次读入 Core 内存的对象大小，内置 Local/S3 实现的硬上限为 `64 MiB`。
+- `storage.cleanup` 控制上传文件与日志的周期清理。`max_files_per_run` 限制一次扫描的文件数，硬上限 `10000`。
+- `storage.s3.max_concurrency` 限制委托给工作线程的同步 boto3 操作数量。
+- `plugin.worker` 定义所有插件安装都不能突破的 CPU、内存、PID、打开文件、文件大小与全局 Worker 预算；插件清单不能抬高这些上限。重启参数用于抑制 Runtime 重启风暴。
+- `plugin.binary_storage.max_value_bytes` 限制单个插件二进制存储值，默认 `10 MiB`。
+- `mcp.lifecycle_concurrency` 限制 MCP 启停并发，硬上限 `128`；`mcp.stdio.enabled` 可独立禁用本地 stdio MCP，而不影响 HTTP/SSE MCP。
+- `monitoring.query_limits` 限制分页、CSV 导出、详情、时序桶和高 offset 查询在内存/数据库中的工作量。
+- `monitoring.auto_cleanup` 控制监控数据保留与分批删除；`max_batches_per_table_per_run` 防止单个 Workspace 的积压长期占用 PostgreSQL。
+
+### Box 沙箱
+
+- `box.enabled` 是总开关。关闭后不会连接或启动 Box Runtime，并禁用原生沙箱工具、Skill 添加/编辑和 stdio MCP；只读 Skill 列表以及 HTTP/SSE MCP 仍可使用。
+- `box.backend` 可选 `local`、`docker`、`nsjail`、`e2b`；`box.runtime.endpoint` 用于连接外部 WebSocket Runtime，留空时使用本地自动管理 Runtime。
+- `box.limits` 限制会话、托管进程、已完成进程、Workspace 扫描条目、准入记录和 RPC 文件大小。
+- `box.admission` 是 Cloud v2 的强制准入与硬资源配额。普通 OSS 默认 `required: false`；流水线、Workspace 权益或工具调用都不能放宽 Runtime 拥有的限制。
+- `box.local` 配置本地工作目录、Skill 根目录、允许挂载根目录和可选磁盘配额。Docker 部署时，`host_root` 应使用 Box 容器可挂载的绝对宿主机路径。
+- `box.default_memory_mb` 是每个 MCP stdio 进程的默认 nsjail cgroup 内存上限。Node.js MCP 通常比 Python MCP 占用更多内存；过低时常见 `return_code=137`。
+- `box.docker.cpu_limit_enabled: false` 只取消 Docker 的 CPU 参数，内存与 PID 限制仍然生效。
+- `box.e2b` 用于 E2B 或自托管兼容服务。
+
+### LangBot Space
+
+- `space.url`：Space OAuth 与 API 服务地址。
+- `space.models_gateway_api_url`：LangBot MaaS 的 OpenAI 兼容模型网关地址。
+- `space.oauth_authorize_url`：OAuth 授权页地址。
+- `space.disable_models_service` / `disable_telemetry`：分别关闭 Space 模型服务与遥测上报。
 
 ## 通过环境变量设置
 
-`config.yaml` 中的配置可以通过环境变量进行设置。环境变量名称为大写字母，使用双下划线连接，例如：`API__PORT` 代表 `api.port`。
+任何嵌套配置都可以转换为“大写 + 双下划线”环境变量：
 
-- `API__PORT` 代表 `api.port`
-- `CONCURRENCY__PIPELINE` 代表 `concurrency.pipeline`
-- `DATABASE__SQLITE__PATH` 代表 `database.sqlite.path`
-- `STORAGE__CLEANUP__UPLOADED_FILE_RETENTION_DAYS` 代表 `storage.cleanup.uploaded_file_retention_days`
-- `STORAGE__CLEANUP__LOG_RETENTION_DAYS` 代表 `storage.cleanup.log_retention_days`
-- `MONITORING__AUTO_CLEANUP__RETENTION_DAYS` 代表 `monitoring.auto_cleanup.retention_days`
-- `PLUGIN__BINARY_STORAGE__MAX_VALUE_BYTES` 代表 `plugin.binary_storage.max_value_bytes`
-- `BOX__ENABLED` 代表 `box.enabled`
-- `BOX__BACKEND` 代表 `box.backend`
-- `BOX__LOCAL__HOST_ROOT` 代表 `box.local.host_root`
-- `BOX__LOCAL__SKILLS_ROOT` 代表 `box.local.skills_root`
+- `API__PORT` → `api.port`
+- `WORKSPACE__INVITATIONS__PUBLIC_WEB_URL` → `workspace.invitations.public_web_url`
+- `CONCURRENCY__PENDING_QUERIES_PER_WORKSPACE` → `concurrency.pending_queries_per_workspace`
+- `DATABASE__POSTGRESQL__POOL_SIZE` → `database.postgresql.pool_size`
+- `STORAGE__CLEANUP__MAX_FILES_PER_RUN` → `storage.cleanup.max_files_per_run`
+- `PLUGIN__WORKER__MAX_TOTAL_MEMORY_MB` → `plugin.worker.max_total_memory_mb`
+- `MCP__STDIO__ENABLED` → `mcp.stdio.enabled`
+- `BOX__DEFAULT_MEMORY_MB` → `box.default_memory_mb`
 
-在启动时，LangBot 会读取所有环境变量，将对应的配置应用到 `config.yaml` 中并写入到 `data/config.yaml` 文件中。
+启动时，LangBot 会读取环境变量、应用对应配置，并写入 `data/config.yaml`。
 
 <Note>
-Box 相关配置应设置在 `langbot` 服务上，使用统一的 `BOX__*` 环境变量。LangBot 会在启动时写入 `data/config.yaml`，并通过 INIT RPC 将 Box 配置传给 `langbot_box`。不要在 `langbot_box` 服务上设置 `LANGBOT_BOX_*` 或 `BOX__*`，这些变量不会被直接读取。
+Docker 部署中，统一把 `BOX__*` 环境变量设置在 `langbot` 服务上。LangBot 会通过 INIT RPC 将 Box 配置传给 `langbot_box`；直接在 `langbot_box` 服务上设置 `LANGBOT_BOX_*` 或 `BOX__*` 不会被读取。
 </Note>


### PR DESCRIPTION
## Summary
- sync the full default config block in Chinese, English, and Japanese with LangBot's current `src/langbot/templates/config.yaml`
- remove stale entries such as `admins` and document newly added workspace invitation, admission, retention, database, plugin worker, MCP, monitoring, and Box settings
- add grouped operational guidance, secret-handling warnings, and environment-variable examples for each locale

## Verification
- canonical YAML blocks are byte-for-byte identical to the LangBot template and parse to the same object
- `node --test tests/*.test.mjs`
- `python3 -m unittest tests/test_build_github_wiki.py`
- GitHub Wiki generator: 263 pages, all three settings pages contain the new keys
- `mintlify validate`
- local Mintlify preview returned HTTP 200 and rendered the new config and explanation markers

Note: `mintlify broken-links` still reports 7 pre-existing unrelated links in four other pages; this change introduces no new links beyond the canonical config source URL.