### PR TITLE
docs: document optional runtime control and rotating debug keys

### DIFF
--- a/en/develop/plugin-runtime.mdx
+++ b/en/develop/plugin-runtime.mdx
@@ -79,6 +79,8 @@ plugin:
 And add the startup parameter `--standalone-runtime` when starting the LangBot main program (e.g., `uv run --no-sync main.py --standalone-runtime`). Make sure to include the `--no-sync` parameter in this command, which ensures that the local langbot-plugin-sdk you just synced will not be overwritten by the remote version.\
 Restart LangBot, and it will connect to this runtime using WebSocket.
 
+`LANGBOT_PLUGIN_RUNTIME_CONTROL_TOKEN` is optional by default. When it is unset on both LangBot and Runtime, the local OSS control connection is established without a token. To protect an exposed port 5400, configure the same high-entropy value of at least 32 characters on both sides; configuring only one side makes the connection fail.
+
 ## langbot-plugin-sdk Architecture
 
 This codebase contains the following:

--- a/en/plugin/dev/tutor.mdx
+++ b/en/plugin/dev/tutor.mdx
@@ -118,7 +118,7 @@ Whether in `stdio` or `websocket` mode, Plugin Runtime will listen on port `5401
 When developing plugins, we recommend starting LangBot according to the [Development Configuration](/en/develop/dev-config) method, which will start Plugin Runtime in Stdio mode, making plugin development easier.
 </Info>
 
-Copy the `.env.example` file in the plugin directory to `.env`, and check or modify `DEBUG_RUNTIME_WS_URL` to your Plugin Runtime's WebSocket address.
+Copy `.env.example` to `.env`. In LangBot WebUI, open **Extensions → Debug Info** and copy the current Workspace's Debug URL and Debug Key into `DEBUG_RUNTIME_WS_URL` and `PLUGIN_DEBUG_KEY`. Every Workspace has a different key, and it rotates every two hours; copy it again after expiry.
 
 ```bash
 cp .env.example .env

--- a/ja/develop/plugin-runtime.mdx
+++ b/ja/develop/plugin-runtime.mdx
@@ -79,6 +79,8 @@ plugin:
 そして、LangBotメインプログラムの起動時に起動パラメーター`--standalone-runtime`を追加します(例: `uv run --no-sync main.py --standalone-runtime`)。このコマンドでは必ず`--no-sync`パラメーターを付けてください。これにより、同期したローカルのlangbot-plugin-sdkがリモート版で上書きされないことが保証されます。\
 LangBotを再起動すると、WebSocketを使用してこのランタイムに接続されます。
 
+`LANGBOT_PLUGIN_RUNTIME_CONTROL_TOKEN` は既定では省略可能です。LangBot と Runtime の両方で未設定の場合、ローカル OSS の制御接続はトークンなしで確立されます。公開された 5400 ポートを保護する場合は、両側に同じ 32 文字以上の高エントロピー値を設定してください。片側だけに設定すると接続は失敗します。
+
 ## langbot-plugin-sdkアーキテクチャ
 
 このコードベースには以下が含まれています:

--- a/ja/plugin/dev/tutor.mdx
+++ b/ja/plugin/dev/tutor.mdx
@@ -118,7 +118,7 @@ cd HelloPlugin
 プラグインを開発する際は、[開発設定](/en/develop/dev-config)方法に従ってLangBotを起動することをお勧めします。これによりPlugin RuntimeがStdioモードで起動され、プラグイン開発が容易になります。
 </Info>
 
-プラグインディレクトリの`.env.example`ファイルを`.env`にコピーし、`DEBUG_RUNTIME_WS_URL`をPlugin RuntimeのWebSocketアドレスに確認または変更します。
+`.env.example` を `.env` にコピーします。LangBot WebUI の **拡張機能 → デバッグ情報** を開き、現在の Workspace のデバッグ URL とデバッグキーを `DEBUG_RUNTIME_WS_URL` と `PLUGIN_DEBUG_KEY` に設定します。キーは Workspace ごとに異なり、2 時間ごとにローテーションするため、期限切れ後は再度コピーしてください。
 
 ```bash
 cp .env.example .env

--- a/zh/develop/plugin-runtime.mdx
+++ b/zh/develop/plugin-runtime.mdx
@@ -79,6 +79,8 @@ plugin:
 并在启动 LangBot 主程序时携带启动参数`--standalone-runtime`（如：`uv run --no-sync main.py --standalone-runtime`）。此命令行中，请务必携带`--no-sync`参数，这将确保您刚刚同步的本地 langbot-plugin-sdk 不会被远程的覆盖。\
 重启 LangBot，将会使用 WebSocket 连接到此运行时。
 
+默认情况下无需配置 `LANGBOT_PLUGIN_RUNTIME_CONTROL_TOKEN`：当 LangBot 与 Runtime 两端都未设置时，OSS 的本地控制连接直接建立。若部署环境需要为 5400 控制端口增加共享密钥，则必须在两端配置同一个至少 32 位的高熵值；只配置一端会导致连接失败。
+
 ## langbot-plugin-sdk 架构
 
 本代码库中包含以下内容：

--- a/zh/plugin/dev/tutor.mdx
+++ b/zh/plugin/dev/tutor.mdx
@@ -118,7 +118,7 @@ cd HelloPlugin
 当您在开发插件时，推荐您按照[开发配置](/zh/develop/dev-config)中的方式 LangBot，此方式将以 Stdio 形式启动 Plugin Runtime，便于插件开发。
 </Info>
 
-复制插件目录下的`.env.example`文件为`.env`，检查或修改`DEBUG_RUNTIME_WS_URL`为您的 Plugin Runtime 的 WebSocket 地址。
+复制插件目录下的`.env.example`文件为`.env`。在 LangBot WebUI 的“扩展 → 调试信息”中复制当前工作区的调试地址和调试密钥，分别填写为 `DEBUG_RUNTIME_WS_URL` 和 `PLUGIN_DEBUG_KEY`。每个工作区的密钥不同，并每两小时自动轮换；过期后请重新复制。
 
 ```bash
 cp .env.example .env


### PR DESCRIPTION
Update Chinese, English, and Japanese Plugin Runtime/development guidance for optional OSS control auth and per-Workspace two-hour rotating debug keys.