### PR TITLE
fix(seo): stop advertising missing alternate sitemap

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -3,4 +3,3 @@ Allow: /
 Allow: /_next/
 
 Sitemap: https://docs.langbot.app/sitemap.xml
-Sitemap: https://docs.langbot.app/sitemap-alternates.xml

--- a/tests/seo.test.mjs
+++ b/tests/seo.test.mjs
@@ -40,7 +40,7 @@ test("custom robots policy is served from the Mintlify project root", async () =
     robots,
     /^Sitemap: https:\/\/docs\.langbot\.app\/sitemap\.xml$/m,
   );
-  assert.match(
+  assert.doesNotMatch(
     robots,
     /^Sitemap: https:\/\/docs\.langbot\.app\/sitemap-alternates\.xml$/m,
   );


### PR DESCRIPTION
## Summary
- remove the robots.txt declaration for sitemap-alternates.xml because that published URL returns 404
- keep the valid primary sitemap declaration
- update the SEO contract test to prevent re-advertising the missing asset

## Evidence
- https://docs.langbot.app/sitemap-alternates.xml currently returns HTTP 404

## Verification
- npm test (8/8 passed)
- npx mintlify validate (passed)
