### PR TITLE
docs(docker): document optional runtime tokens

### DIFF
--- a/en/deploy/langbot/docker.mdx
+++ b/en/deploy/langbot/docker.mdx
@@ -27,6 +27,18 @@ Start the containers with the recommended `all` profile, which enables Box Runti
 docker compose --profile all up
 ```
 
+## Runtime tokens for Internet-accessible deployments
+
+The open-source edition skips token verification only when **both LangBot and the corresponding Runtime leave the token unset**. If the deployment is accessible from the Internet, strongly protect Plugin Runtime and Box Runtime with separate strong tokens:
+
+```bash
+export LANGBOT_PLUGIN_RUNTIME_CONTROL_TOKEN="$(openssl rand -hex 32)"
+export LANGBOT_BOX_CONTROL_TOKEN="$(openssl rand -hex 32)"
+docker compose --profile all up -d
+```
+
+The official Compose file passes each variable to both ends of its connection. Setting only one end, using different values, or using a weak token causes the connection to be rejected. Store tokens in your deployment platform's secret manager and never commit them.
+
 This starts `langbot`, `langbot_plugin_runtime`, and `langbot_box`. If you only need the basic services and do not want to enable Box Runtime, run:
 
 ```bash

--- a/ja/deploy/langbot/docker.mdx
+++ b/ja/deploy/langbot/docker.mdx
@@ -26,6 +26,18 @@ cd LangBot/docker
 docker compose --profile all up
 ```
 
+## インターネット公開時の Runtime Token
+
+オープンソース版で Token 検証が省略されるのは、**LangBot と対応する Runtime の両方で Token が未設定の場合のみ**です。インターネットからアクセス可能な環境では、Plugin Runtime と Box Runtime にそれぞれ強力な Token を設定することを強く推奨します：
+
+```bash
+export LANGBOT_PLUGIN_RUNTIME_CONTROL_TOKEN="$(openssl rand -hex 32)"
+export LANGBOT_BOX_CONTROL_TOKEN="$(openssl rand -hex 32)"
+docker compose --profile all up -d
+```
+
+公式 Compose ファイルは、各変数を対応する接続の両端に渡します。片側だけの設定、値の不一致、または強度不足の Token は接続拒否の原因になります。Token はデプロイ環境の Secret 管理に保存し、リポジトリへコミットしないでください。
+
 これにより `langbot`、`langbot_plugin_runtime`、`langbot_box` が起動します。Box Runtime を有効にせず、基本サービスのみを使う場合は次を実行します：
 
 ```bash

--- a/zh/deploy/langbot/docker.mdx
+++ b/zh/deploy/langbot/docker.mdx
@@ -27,6 +27,18 @@ cd LangBot/docker
 docker compose --profile all up
 ```
 
+## 公网部署的 Runtime Token
+
+开源版仅在 LangBot 与对应 Runtime **两端都未设置 Token** 时跳过 Token 校验。若部署环境可从公网访问，强烈建议为 Plugin Runtime 和 Box Runtime 设置独立的强 Token：
+
+```bash
+export LANGBOT_PLUGIN_RUNTIME_CONTROL_TOKEN="$(openssl rand -hex 32)"
+export LANGBOT_BOX_CONTROL_TOKEN="$(openssl rand -hex 32)"
+docker compose --profile all up -d
+```
+
+官方 Compose 文件会把每个变量传给对应连接的两端。只设置一端、两端值不一致或 Token 强度不足都会导致连接被拒绝。请把 Token 保存在部署平台的 Secret 管理中，不要提交到仓库。
+
 这会启动 `langbot`、`langbot_plugin_runtime` 和 `langbot_box`。如果只需要基础服务，不启用 Box Runtime，可以使用：
 
 ```bash


### PR DESCRIPTION
## Summary
- document optional Plugin Runtime and Box Runtime tokens on the Docker deployment page
- explain tokenless OSS behavior when both endpoints leave the token unset
- recommend strong tokens for Internet-accessible deployments
- add matching Chinese, English, and Japanese instructions

## Verification
- `npx mintlify validate`
- `git diff --check`